### PR TITLE
(fix) Explicitly name docker containers

### DIFF
--- a/bin/dspec
+++ b/bin/dspec
@@ -4,8 +4,8 @@ set -e
 if [ $# -eq 0 ]
 then
   echo "No arguments supplied. Defaults to 'rake default'"
-  docker exec -it data-submission-service-api_test_1 rake default $@
+  docker exec -it data-submission-service-api_test rake default $@
 else
   echo "Testing: $@"
-  docker exec -it data-submission-service-api_test_1 rspec $@
+  docker exec -it data-submission-service-api_test rspec $@
 fi

--- a/bin/dstart
+++ b/bin/dstart
@@ -19,4 +19,4 @@ trap cleanup EXIT
 
 docker-compose up -d
 
-docker attach data-submission-service-api_web_1
+docker attach data-submission-service-api_web

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -19,6 +19,7 @@ services:
     restart: on-failure
     networks:
       - tests
+    container_name: data-submission-service-api_test
 
   db-test:
     image: postgres
@@ -27,6 +28,7 @@ services:
     networks:
       - tests
     restart: on-failure
+    container_name: data-submission-service-api_db-test
 
 networks:
   tests:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,14 @@ services:
     volumes:
       - .:/srv/dss-api:cached
     command: bash -c "rm -f tmp/pids/server.pid && rails s"
+    container_name: "data-submission-service-api_web"
 
   db:
     image: postgres
     volumes:
       - pg_data:/var/lib/postgresql/data/:cached
     restart: on-failure
+    container_name: "data-submission-service-api_db"
 
 volumes:
   pg_data: {}


### PR DESCRIPTION
Update docker-compose files and scripts to use explicit container names.

Without an explicit `container_name` docker uses the parent folder to build the name of the container. Unless you have the right folder name, the hardcoded container names in `bin/dstart` and `bin/dspec` won't exist and the script will fail.