### PR TITLE
(18) Add Agreement model, which associates Suppliers to Frameworks

### DIFF
--- a/app/controllers/v1/agreements_controller.rb
+++ b/app/controllers/v1/agreements_controller.rb
@@ -1,0 +1,14 @@
+class V1::AgreementsController < ApplicationController
+  def create
+    framework = Framework.find(agreement_params[:framework_id])
+    supplier = Supplier.find(agreement_params[:supplier_id])
+
+    Agreement.create!(framework: framework, supplier: supplier)
+  end
+
+  private
+
+  def agreement_params
+    params.permit(:framework_id, :supplier_id)
+  end
+end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -1,0 +1,4 @@
+class Agreement < ApplicationRecord
+  belongs_to :supplier
+  belongs_to :framework
+end

--- a/app/models/agreement.rb
+++ b/app/models/agreement.rb
@@ -1,4 +1,7 @@
 class Agreement < ApplicationRecord
   belongs_to :supplier
   belongs_to :framework
+
+  validates :supplier_id, presence: true
+  validates :framework_id, presence: true
 end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -1,7 +1,7 @@
 class Framework < ApplicationRecord
   has_many :lots, dependent: :nullify, class_name: 'FrameworkLot'
 
-  has_many :agreements
+  has_many :agreements, dependent: :destroy
   has_many :suppliers, through: :agreements
 
   validates :short_name, presence: true, uniqueness: true

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -1,5 +1,8 @@
 class Framework < ApplicationRecord
   has_many :lots, dependent: :nullify, class_name: 'FrameworkLot'
 
+  has_many :agreements
+  has_many :suppliers, through: :agreements
+
   validates :short_name, presence: true, uniqueness: true
 end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,3 +1,6 @@
 class Supplier < ApplicationRecord
+  has_many :agreements
+  has_many :frameworks, through: :agreements
+
   validates :name, presence: true
 end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,5 +1,5 @@
 class Supplier < ApplicationRecord
-  has_many :agreements
+  has_many :agreements, dependent: :destroy
   has_many :frameworks, through: :agreements
 
   validates :name, presence: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,5 +5,6 @@ Rails.application.routes.draw do
   namespace :v1, defaults: { format: :json } do
     resources :frameworks, only: %i[index show]
     resources :suppliers, only: %i[index show]
+    resources :agreements, only: %i[create]
   end
 end

--- a/db/migrate/20180530100814_create_agreement.rb
+++ b/db/migrate/20180530100814_create_agreement.rb
@@ -1,0 +1,8 @@
+class CreateAgreement < ActiveRecord::Migration[5.2]
+  def change
+    create_table :agreements, id: :uuid do |t|
+      t.references :framework, type: :uuid, null: false
+      t.references :supplier, type: :uuid, null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,16 +10,22 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_29_154004) do
+ActiveRecord::Schema.define(version: 2018_05_30_100814) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
+  create_table "agreements", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "framework_id", null: false
+    t.uuid "supplier_id", null: false
+    t.index ["framework_id"], name: "index_agreements_on_framework_id"
+    t.index ["supplier_id"], name: "index_agreements_on_supplier_id"
+  end
+
   create_table "framework_lots", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false
     t.string "number", null: false
-    t.string "description"
     t.index ["framework_id", "number"], name: "index_framework_lots_on_framework_id_and_number", unique: true
     t.index ["framework_id"], name: "index_framework_lots_on_framework_id"
   end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,7 @@ ActiveRecord::Schema.define(version: 2018_05_30_100814) do
   create_table "framework_lots", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false
     t.string "number", null: false
+    t.string "description"
     t.index ["framework_id", "number"], name: "index_framework_lots_on_framework_id_and_number", unique: true
     t.index ["framework_id"], name: "index_framework_lots_on_framework_id"
   end

--- a/spec/models/agreement_spec.rb
+++ b/spec/models/agreement_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Agreement do
+  it { is_expected.to validate_presence_of(:framework_id) }
+  it { is_expected.to validate_presence_of(:supplier_id) }
+end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Framework do
   it { is_expected.to have_many(:lots) }
+  it { is_expected.to have_many(:agreements) }
+  it { is_expected.to have_many(:suppliers).through(:agreements) }
 
   describe 'validations' do
     subject { Framework.create(short_name: 'test') }

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -2,4 +2,7 @@ require 'rails_helper'
 
 RSpec.describe Supplier do
   it { is_expected.to validate_presence_of(:name) }
+
+  it { is_expected.to have_many(:agreements) }
+  it { is_expected.to have_many(:frameworks).through(:agreements) }
 end

--- a/spec/requests/v1/agreements_spec.rb
+++ b/spec/requests/v1/agreements_spec.rb
@@ -1,0 +1,18 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  describe 'POST /agreements' do
+    it 'creates an agreement between the given framework and supplier' do
+      framework = FactoryBot.create(:framework, name: 'Cheese Board 8', short_name: 'cboard8')
+      supplier  = FactoryBot.create(:supplier, name: 'Cheesy Does It')
+
+      post "/v1/agreements?framework_id=#{framework.id}&supplier_id=#{supplier.id}"
+
+      expect(response).to be_successful
+
+      agreement = Agreement.first
+      expect(agreement.framework).to eql framework
+      expect(agreement.supplier).to eql supplier
+    end
+  end
+end


### PR DESCRIPTION
I originally was going to create this as a [HABTM](http://guides.rubyonrails.org/association_basics.html#choosing-between-has-many-through-and-has-and-belongs-to-many) association, but decided that the joining model will probably contain some additional metadata, such as the joining/leaving date of suppliers on frameworks, so made it a distinct model.

Also, `Agreement` was the best name we could come up with for the relationship between `Supplier` and `Framework`. 