### PR TITLE
(74) API ingest endpoints

### DIFF
--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -1,9 +1,6 @@
 class V1::SubmissionEntriesController < ApplicationController
   def create
-    file = SubmissionFile.find(submission_entry_params[:file_id])
-
-    @entry = file.entries.new
-    @entry.submission = file.submission
+    @entry = initialize_submission_entry
 
     @entry.source = submission_entry_params[:source]
     @entry.data = submission_entry_params[:data]
@@ -16,6 +13,16 @@ class V1::SubmissionEntriesController < ApplicationController
   end
 
   private
+
+  def initialize_submission_entry
+    if submission_entry_params[:file_id].present?
+      file = SubmissionFile.find(submission_entry_params[:file_id])
+      file.entries.new(submission: file.submission)
+    else
+      submission = Submission.find(submission_entry_params[:submission_id])
+      submission.entries.new
+    end
+  end
 
   def submission_entry_params
     params.permit(:file_id, :submission_id, source: {}, data: {})

--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -1,0 +1,23 @@
+class V1::SubmissionEntriesController < ApplicationController
+  def create
+    file = SubmissionFile.find(submission_entry_params[:file_id])
+
+    @entry = file.entries.new
+    @entry.submission = file.submission
+
+    @entry.source = submission_entry_params[:source]
+    @entry.data = submission_entry_params[:data]
+
+    if @entry.save
+      render json: @entry, status: :created
+    else
+      render json: @entry.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def submission_entry_params
+    params.permit(:file_id, :submission_id, source: {}, data: {})
+  end
+end

--- a/app/controllers/v1/submission_files_controller.rb
+++ b/app/controllers/v1/submission_files_controller.rb
@@ -1,0 +1,19 @@
+class V1::SubmissionFilesController < ApplicationController
+  def create
+    submission = Submission.find(submission_file_params[:submission_id])
+
+    @submission_file = submission.files.new
+
+    if @submission_file.save
+      render json: @submission_file, status: :created
+    else
+      render json: @submission_file.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def submission_file_params
+    params.permit(:submission_id)
+  end
+end

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -1,0 +1,20 @@
+class V1::SubmissionsController < ApplicationController
+  def create
+    framework = Framework.find(submission_params[:framework_id])
+    supplier = Supplier.find(submission_params[:supplier_id])
+
+    @submission = Submission.new(framework: framework, supplier: supplier)
+
+    if @submission.save
+      render json: @submission, status: :created
+    else
+      render json: @submission.errors, status: :bad_request
+    end
+  end
+
+  private
+
+  def submission_params
+    params.permit(:framework_id, :supplier_id, :source, :data)
+  end
+end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -1,5 +1,6 @@
 class Framework < ApplicationRecord
   has_many :lots, dependent: :nullify, class_name: 'FrameworkLot'
+  has_many :submissions, dependent: :nullify
 
   has_many :agreements, dependent: :destroy
   has_many :suppliers, through: :agreements

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,0 +1,4 @@
+class Submission < ApplicationRecord
+  belongs_to :framework
+  belongs_to :supplier
+end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -2,4 +2,5 @@ class Submission < ApplicationRecord
   belongs_to :framework
   belongs_to :supplier
   has_many :files, dependent: :nullify, class_name: 'SubmissionFile'
+  has_many :entries, dependent: :nullify, class_name: 'SubmissionEntry'
 end

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -1,4 +1,5 @@
 class Submission < ApplicationRecord
   belongs_to :framework
   belongs_to :supplier
+  has_many :files, dependent: :nullify, class_name: 'SubmissionFile'
 end

--- a/app/models/submission_entry.rb
+++ b/app/models/submission_entry.rb
@@ -1,0 +1,4 @@
+class SubmissionEntry < ApplicationRecord
+  belongs_to :submission
+  belongs_to :submission_file, optional: true
+end

--- a/app/models/submission_entry.rb
+++ b/app/models/submission_entry.rb
@@ -1,4 +1,6 @@
 class SubmissionEntry < ApplicationRecord
   belongs_to :submission
   belongs_to :submission_file, optional: true
+
+  validates :data, presence: true
 end

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -1,3 +1,4 @@
 class SubmissionFile < ApplicationRecord
   belongs_to :submission
+  has_many :entries, dependent: :nullify, class_name: 'SubmissionEntry'
 end

--- a/app/models/submission_file.rb
+++ b/app/models/submission_file.rb
@@ -1,0 +1,3 @@
+class SubmissionFile < ApplicationRecord
+  belongs_to :submission
+end

--- a/app/models/supplier.rb
+++ b/app/models/supplier.rb
@@ -1,6 +1,7 @@
 class Supplier < ApplicationRecord
   has_many :agreements, dependent: :destroy
   has_many :frameworks, through: :agreements
+  has_many :submissions, dependent: :nullify
 
   validates :name, presence: true
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,8 @@ Rails.application.routes.draw do
     resources :frameworks, only: %i[index show]
     resources :suppliers, only: %i[index show]
     resources :agreements, only: %i[create]
-    resources :submissions, only: %i[create]
+    resources :submissions, only: %i[create] do
+      resources :files, only: %i[create], controller: 'submission_files'
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,5 +6,6 @@ Rails.application.routes.draw do
     resources :frameworks, only: %i[index show]
     resources :suppliers, only: %i[index show]
     resources :agreements, only: %i[create]
+    resources :submissions, only: %i[create]
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[create] do
       resources :files, only: %i[create], controller: 'submission_files'
+      resources :entries, only: %i[create], controller: 'submission_entries'
     end
 
     resources :files, only: [] do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,5 +9,9 @@ Rails.application.routes.draw do
     resources :submissions, only: %i[create] do
       resources :files, only: %i[create], controller: 'submission_files'
     end
+
+    resources :files, only: [] do
+      resources :entries, only: %i[create], controller: 'submission_entries'
+    end
   end
 end

--- a/db/migrate/20180530150849_create_submission.rb
+++ b/db/migrate/20180530150849_create_submission.rb
@@ -1,0 +1,8 @@
+class CreateSubmission < ActiveRecord::Migration[5.2]
+  def change
+    create_table :submissions, id: :uuid do |t|
+      t.references :framework, foreign_key: true, null: false, type: :uuid
+      t.references :supplier, foreign_key: true, null: false, type: :uuid
+    end
+  end
+end

--- a/db/migrate/20180530164708_create_submission_file.rb
+++ b/db/migrate/20180530164708_create_submission_file.rb
@@ -1,0 +1,7 @@
+class CreateSubmissionFile < ActiveRecord::Migration[5.2]
+  def change
+    create_table :submission_files, id: :uuid do |t|
+      t.references :submission, foreign_key: true, null: false, type: :uuid
+    end
+  end
+end

--- a/db/migrate/20180604105000_create_submission_entry.rb
+++ b/db/migrate/20180604105000_create_submission_entry.rb
@@ -1,0 +1,13 @@
+class CreateSubmissionEntry < ActiveRecord::Migration[5.2]
+  def change
+    create_table :submission_entries, id: :uuid do |t|
+      t.references :submission, foreign_key: true, null: false, type: :uuid
+      t.references :submission_file, foreign_key: true, null: true, type: :uuid
+
+      t.jsonb :source
+      t.jsonb :data
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_30_100814) do
+ActiveRecord::Schema.define(version: 2018_05_30_164708) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -37,9 +37,24 @@ ActiveRecord::Schema.define(version: 2018_05_30_100814) do
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 
+  create_table "submission_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "submission_id", null: false
+    t.index ["submission_id"], name: "index_submission_files_on_submission_id"
+  end
+
+  create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "framework_id", null: false
+    t.uuid "supplier_id", null: false
+    t.index ["framework_id"], name: "index_submissions_on_framework_id"
+    t.index ["supplier_id"], name: "index_submissions_on_supplier_id"
+  end
+
   create_table "suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
   end
 
   add_foreign_key "framework_lots", "frameworks"
+  add_foreign_key "submission_files", "submissions"
+  add_foreign_key "submissions", "frameworks"
+  add_foreign_key "submissions", "suppliers"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_05_30_164708) do
+ActiveRecord::Schema.define(version: 2018_06_04_105000) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -37,6 +37,17 @@ ActiveRecord::Schema.define(version: 2018_05_30_164708) do
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 
+  create_table "submission_entries", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.uuid "submission_id", null: false
+    t.uuid "submission_file_id"
+    t.jsonb "source"
+    t.jsonb "data"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["submission_file_id"], name: "index_submission_entries_on_submission_file_id"
+    t.index ["submission_id"], name: "index_submission_entries_on_submission_id"
+  end
+
   create_table "submission_files", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "submission_id", null: false
     t.index ["submission_id"], name: "index_submission_files_on_submission_id"
@@ -54,6 +65,8 @@ ActiveRecord::Schema.define(version: 2018_05_30_164708) do
   end
 
   add_foreign_key "framework_lots", "frameworks"
+  add_foreign_key "submission_entries", "submission_files"
+  add_foreign_key "submission_entries", "submissions"
   add_foreign_key "submission_files", "submissions"
   add_foreign_key "submissions", "frameworks"
   add_foreign_key "submissions", "suppliers"

--- a/spec/factories/framework.rb
+++ b/spec/factories/framework.rb
@@ -1,4 +1,6 @@
 FactoryBot.define do
   factory :framework do
+    sequence(:short_name) { |n| "RM#{n + 1000}" }
+    sequence(:name) { |n| "G Cloud #{n}" }
   end
 end

--- a/spec/factories/submission.rb
+++ b/spec/factories/submission.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :submission do
+    framework
+    supplier
+  end
+end

--- a/spec/factories/submission_file.rb
+++ b/spec/factories/submission_file.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :submission_file do
+    submission
+  end
+end

--- a/spec/factories/supplier.rb
+++ b/spec/factories/supplier.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
   factory :supplier do
+    sequence(:name) { |n| "Supplier ##{n} Ltd" }
   end
 end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe Framework do
   it { is_expected.to have_many(:lots) }
   it { is_expected.to have_many(:agreements) }
   it { is_expected.to have_many(:suppliers).through(:agreements) }
+  it { is_expected.to have_many(:submissions) }
 
   describe 'validations' do
     subject { Framework.create(short_name: 'test') }

--- a/spec/models/submission_entry_spec.rb
+++ b/spec/models/submission_entry_spec.rb
@@ -3,4 +3,6 @@ require 'rails_helper'
 RSpec.describe SubmissionEntry do
   it { is_expected.to belong_to(:submission) }
   it { is_expected.to belong_to(:submission_file) }
+
+  it { is_expected.to validate_presence_of(:data) }
 end

--- a/spec/models/submission_entry_spec.rb
+++ b/spec/models/submission_entry_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionEntry do
+  it { is_expected.to belong_to(:submission) }
+  it { is_expected.to belong_to(:submission_file) }
+end

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -2,4 +2,5 @@ require 'rails_helper'
 
 RSpec.describe SubmissionFile do
   it { is_expected.to belong_to(:submission) }
+  it { is_expected.to have_many(:entries) }
 end

--- a/spec/models/submission_file_spec.rb
+++ b/spec/models/submission_file_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe SubmissionFile do
+  it { is_expected.to belong_to(:submission) }
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -1,0 +1,6 @@
+require 'rails_helper'
+
+RSpec.describe Submission do
+  it { is_expected.to belong_to(:framework) }
+  it { is_expected.to belong_to(:supplier) }
+end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -3,4 +3,5 @@ require 'rails_helper'
 RSpec.describe Submission do
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:supplier) }
+  it { is_expected.to have_many(:files) }
 end

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -4,4 +4,5 @@ RSpec.describe Submission do
   it { is_expected.to belong_to(:framework) }
   it { is_expected.to belong_to(:supplier) }
   it { is_expected.to have_many(:files) }
+  it { is_expected.to have_many(:entries) }
 end

--- a/spec/models/supplier_spec.rb
+++ b/spec/models/supplier_spec.rb
@@ -1,6 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Supplier do
+  it { is_expected.to have_many(:submissions) }
   it { is_expected.to validate_presence_of(:name) }
 
   it { is_expected.to have_many(:agreements) }

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -1,0 +1,29 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  describe 'POST /files/:file_id/entries' do
+    it 'stores a submission entry, associated with a file' do
+      file = FactoryBot.create(:submission_file)
+
+      params = {
+        source: { sheet: 'InvoicesReceived', row: 42 },
+        data: { test: 'test' }
+      }
+
+      headers = {
+        'CONTENT_TYPE': 'application/json'
+      }
+
+      post "/v1/files/#{file.id}/entries", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:created)
+
+      entry = SubmissionEntry.first
+
+      expect(json['id']).to eql entry.id
+      expect(json['source']['sheet']).to eql 'InvoicesReceived'
+      expect(json['source']['row']).to eql 42
+      expect(json['data']['test']).to eql 'test'
+    end
+  end
+end

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -25,5 +25,21 @@ RSpec.describe '/v1' do
       expect(json['source']['row']).to eql 42
       expect(json['data']['test']).to eql 'test'
     end
+
+    it 'returns an error if the "data" parameter is omitted' do
+      file = FactoryBot.create(:submission_file)
+
+      params = {
+        source: { sheet: 'Orders', row: 1 }
+      }
+
+      headers = {
+        'CONTENT_TYPE': 'application/json'
+      }
+
+      post "/v1/files/#{file.id}/entries", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:bad_request)
+    end
   end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  describe 'POST /submissions' do
+    it 'creates a new submission and returns its id' do
+      framework = FactoryBot.create(:framework, name: 'Cheese Board 8', short_name: 'cboard8')
+      supplier  = FactoryBot.create(:supplier, name: 'Cheesy Does It')
+
+      post "/v1/submissions?framework_id=#{framework.id}&supplier_id=#{supplier.id}"
+
+      expect(response).to have_http_status(:created)
+
+      submission = Submission.first
+      expect(json['id']).to eql submission.id
+    end
+  end
+end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -28,4 +28,33 @@ RSpec.describe '/v1' do
       expect(json['submission_id']).to eql submission.id
     end
   end
+
+  describe 'POST /submissions/:submission_id/entries' do
+    it 'stores a submission entry, not associated with a file' do
+      submission = FactoryBot.create(:submission)
+
+      params = {
+        source: { sheet: 'InvoicesReceived', row: 42 },
+        data: { test: 'test' }
+      }
+
+      headers = {
+        'CONTENT_TYPE': 'application/json'
+      }
+
+      post "/v1/submissions/#{submission.id}/entries", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:created)
+
+      entry = SubmissionEntry.first
+
+      expect(json['id']).to eql entry.id
+      expect(json['submission_id']).to eql submission.id
+      expect(json['submission_file_id']).to be_nil
+
+      expect(json['source']['sheet']).to eql 'InvoicesReceived'
+      expect(json['source']['row']).to eql 42
+      expect(json['data']['test']).to eql 'test'
+    end
+  end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -14,4 +14,18 @@ RSpec.describe '/v1' do
       expect(json['id']).to eql submission.id
     end
   end
+
+  describe 'POST /submissions/:submission_id/files' do
+    it 'creates a new submission file and returns its id' do
+      submission = FactoryBot.create(:submission)
+
+      post "/v1/submissions/#{submission.id}/files"
+
+      expect(response).to have_http_status(:created)
+
+      file = SubmissionFile.first
+      expect(json['id']).to eql file.id
+      expect(json['submission_id']).to eql submission.id
+    end
+  end
 end


### PR DESCRIPTION
Add models and API endpoints for storing submissions and associated data:

 - `POST /v1/submissions/` - create a submission
 - `POST /v1/submissions/:submission_id/files/` - create a file, associated with a submission
 - `POST /v1/files/:file_id/entries` - store an entry (e.g. spreadsheet row), associated with a file
 - `POST /v1/submissions/:submission_id/entries/` - store an entry, associated to a submission directly, rather than with a file)
