### PR TITLE
(80) API Tasks endpoints

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -9,11 +9,16 @@ class V1::TasksController < ApplicationController
   end
 
   def index
-    if params[:status].present?
-      @tasks = Task.where(status: params[:status])
-    else
-      @tasks = Task.all
-    end
+    @tasks = if params[:status].present?
+               Task.where(status: params[:status])
+             else
+               Task.all
+             end
+  end
+
+  def complete
+    @task = Task.find(params[:id])
+    @task.update(status: 'completed')
   end
 
   private

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -9,7 +9,11 @@ class V1::TasksController < ApplicationController
   end
 
   def index
-    @tasks = Task.all
+    if params[:status].present?
+      @tasks = Task.where(status: params[:status])
+    else
+      @tasks = Task.all
+    end
   end
 
   private

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -1,0 +1,20 @@
+class V1::TasksController < ApplicationController
+  def create
+    @task = Task.new(task_params)
+    if @task.save
+      render json: @task, status: :created
+    else
+      render json: @task.errors, status: :bad_request
+    end
+  end
+
+  def index
+    @tasks = Task.all
+  end
+
+  private
+
+  def task_params
+    params.permit(:status)
+  end
+end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,0 +1,3 @@
+class Task < ApplicationRecord
+  validates :status, presence: true
+end

--- a/app/views/v1/tasks/index.json.jbuilder
+++ b/app/views/v1/tasks/index.json.jbuilder
@@ -1,0 +1,1 @@
+json.tasks @tasks

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Rails.application.routes.draw do
       resources :files, only: %i[create], controller: 'submission_files'
       resources :entries, only: %i[create], controller: 'submission_entries'
     end
+    resources :tasks, only: %i[create index]
 
     resources :files, only: [] do
       resources :entries, only: %i[create], controller: 'submission_entries'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,7 +10,11 @@ Rails.application.routes.draw do
       resources :files, only: %i[create], controller: 'submission_files'
       resources :entries, only: %i[create], controller: 'submission_entries'
     end
-    resources :tasks, only: %i[create index]
+    resources :tasks, only: %i[create index] do
+      member do
+        post 'complete', to: 'tasks#complete'
+      end
+    end
 
     resources :files, only: [] do
       resources :entries, only: %i[create], controller: 'submission_entries'

--- a/db/migrate/20180608092241_create_tasks.rb
+++ b/db/migrate/20180608092241_create_tasks.rb
@@ -1,0 +1,10 @@
+class CreateTasks < ActiveRecord::Migration[5.2]
+  def change
+    create_table :tasks, id: :uuid do |t|
+      t.string :status, null: false
+
+      t.timestamps
+    end
+    add_index :tasks, :status
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_04_105000) do
+ActiveRecord::Schema.define(version: 2018_06_08_092241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -62,6 +62,13 @@ ActiveRecord::Schema.define(version: 2018_06_04_105000) do
 
   create_table "suppliers", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.string "name", null: false
+  end
+
+  create_table "tasks", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
+    t.string "status", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_tasks_on_status"
   end
 
   add_foreign_key "framework_lots", "frameworks"

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :task do
+    status 'MyString'
+  end
+end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Task do
+  it { is_expected.to validate_presence_of(:status) }
+end

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe '/v1' do
 
   describe 'GET /tasks' do
     it 'returns a list of tasks' do
-      FactoryBot.create(:task, status: 'test')
-      FactoryBot.create(:task, status: 'ready')
-      FactoryBot.create(:task, status: 'in progress')
+      task1 = FactoryBot.create(:task, status: 'test')
+      task2 = FactoryBot.create(:task, status: 'ready')
+      task3 = FactoryBot.create(:task, status: 'in progress')
 
       get '/v1/tasks'
 
@@ -46,9 +46,9 @@ RSpec.describe '/v1' do
 
       expected = {
         tasks: [
-          { status: 'test' },
-          { status: 'ready' },
-          { status: 'in progress' }
+          { id: task1.id, status: 'test' },
+          { id: task2.id, status: 'ready' },
+          { id: task3.id, status: 'in progress' }
         ]
       }
 

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -35,9 +35,9 @@ RSpec.describe '/v1' do
 
   describe 'GET /tasks' do
     it 'returns a list of tasks' do
-      FactoryBot.create(:task, status: 'Test')
-      FactoryBot.create(:task, status: 'Ready')
-      FactoryBot.create(:task, status: 'In Progress')
+      FactoryBot.create(:task, status: 'test')
+      FactoryBot.create(:task, status: 'ready')
+      FactoryBot.create(:task, status: 'in progress')
 
       get '/v1/tasks'
 
@@ -46,9 +46,30 @@ RSpec.describe '/v1' do
 
       expected = {
         tasks: [
-          { status: 'Test' },
-          { status: 'Ready'},
-          { status: 'In Progress'}
+          { status: 'test' },
+          { status: 'ready'},
+          { status: 'in progress'}
+        ]
+      }
+
+      expect(response.body).to include_json(expected)
+    end
+  end
+
+  describe 'GET /tasks?status=' do
+    it 'returns a filtered list of tasks matching the statue value in the URL' do
+      FactoryBot.create(:task, status: 'test')
+      FactoryBot.create(:task, status: 'ready')
+      FactoryBot.create(:task, status: 'in progress')
+
+      get '/v1/tasks?status=test'
+
+      expect(response).to be_successful
+      expect(json['tasks'].size).to eql 1
+
+      expected = {
+        tasks: [
+          { status: 'test' }
         ]
       }
 

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -47,8 +47,8 @@ RSpec.describe '/v1' do
       expected = {
         tasks: [
           { status: 'test' },
-          { status: 'ready'},
-          { status: 'in progress'}
+          { status: 'ready' },
+          { status: 'in progress' }
         ]
       }
 
@@ -74,6 +74,20 @@ RSpec.describe '/v1' do
       }
 
       expect(response.body).to include_json(expected)
+    end
+  end
+
+  describe 'POST /v1/tasks/:task_id/complete' do
+    it "changes a task's status to completed" do
+      task = FactoryBot.create(:task, status: 'in progress')
+
+      post "/v1/tasks/#{task.id}/complete"
+
+      expect(response).to be_successful
+
+      task.reload
+
+      expect(task.status).to eql 'completed'
     end
   end
 end

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -1,0 +1,58 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  describe 'POST /tasks' do
+    it 'creates a new task' do
+      params = {
+        status: 'test'
+      }
+
+      headers = {
+        'CONTENT_TYPE': 'application/json'
+      }
+
+      post '/v1/tasks', params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:created)
+
+      task = Task.first
+
+      expect(json['id']).to eql task.id
+      expect(json['status']).to eql task.status
+    end
+
+    it 'returns an error if the status parameter is ommited' do
+      params = {}
+
+      headers = {
+        'CONTENT_TYPE': 'application/json'
+      }
+      post '/v1/tasks', params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+
+  describe 'GET /tasks' do
+    it 'returns a list of tasks' do
+      FactoryBot.create(:task, status: 'Test')
+      FactoryBot.create(:task, status: 'Ready')
+      FactoryBot.create(:task, status: 'In Progress')
+
+      get '/v1/tasks'
+
+      expect(response).to be_successful
+      expect(json['tasks'].size).to eql 3
+
+      expected = {
+        tasks: [
+          { status: 'Test' },
+          { status: 'Ready'},
+          { status: 'In Progress'}
+        ]
+      }
+
+      expect(response.body).to include_json(expected)
+    end
+  end
+end


### PR DESCRIPTION
# Description
This PR adds model and API endpoints for tasks:
- `POST v1/tasks` - create a task
- `GET v1/tasks` - retrieve all tasks
- `GET v1/tasks?status=` - retrieve tasks filtered by status
- `POST v1/tasks/:task_id/complete` - update a task's status to 'completed'

# Status
Ready for review

# Trello card

https://trello.com/c/aYYUXEmC/80-system-has-a-basic-task-list-that-can-be-accessed-via-the-api