### PR TITLE
(93) Basic JSON API endpoints

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,9 @@ gem 'rubocop'
 # Audit log
 gem 'rails_event_store'
 
+# JSON API
+gem 'jsonapi-rails'
+
 group :development, :test do
   gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
@@ -46,6 +49,7 @@ end
 
 group :test do
   gem 'database_cleaner'
+  gem 'jsonapi-rspec', require: false
   gem 'rails_event_store-rspec'
   gem 'rspec-json_expectations'
   gem 'shoulda-matchers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -73,6 +73,18 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
+    jsonapi-deserializable (0.2.0)
+    jsonapi-parser (0.1.1)
+    jsonapi-rails (0.3.1)
+      jsonapi-parser (~> 0.1.0)
+      jsonapi-rb (~> 0.5.0)
+    jsonapi-rb (0.5.0)
+      jsonapi-deserializable (~> 0.2.0)
+      jsonapi-serializable (~> 0.3.0)
+    jsonapi-renderer (0.2.0)
+    jsonapi-rspec (0.0.2)
+    jsonapi-serializable (0.3.0)
+      jsonapi-renderer (~> 0.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
@@ -218,6 +230,8 @@ DEPENDENCIES
   database_cleaner
   factory_bot_rails
   jbuilder (~> 2.5)
+  jsonapi-rails
+  jsonapi-rspec
   listen (>= 3.0.5, < 3.2)
   pg (>= 0.18, < 2.0)
   pry-rails

--- a/app/controllers/v1/agreements_controller.rb
+++ b/app/controllers/v1/agreements_controller.rb
@@ -3,7 +3,13 @@ class V1::AgreementsController < ApplicationController
     framework = Framework.find(agreement_params[:framework_id])
     supplier = Supplier.find(agreement_params[:supplier_id])
 
-    Agreement.create!(framework: framework, supplier: supplier)
+    agreement = Agreement.new(framework: framework, supplier: supplier)
+
+    if agreement.save
+      render jsonapi: agreement, status: :created
+    else
+      render jsonapi_errors: agreement.errors, status: :bad_request
+    end
   end
 
   private

--- a/app/controllers/v1/frameworks_controller.rb
+++ b/app/controllers/v1/frameworks_controller.rb
@@ -1,6 +1,6 @@
 class V1::FrameworksController < ApplicationController
   def index
-    @frameworks = Framework.all
+    render jsonapi: Framework.all
   end
 
   def show

--- a/app/controllers/v1/frameworks_controller.rb
+++ b/app/controllers/v1/frameworks_controller.rb
@@ -4,6 +4,6 @@ class V1::FrameworksController < ApplicationController
   end
 
   def show
-    @framework = Framework.find_by(id: params[:id])
+    render jsonapi: Framework.find(params[:id])
   end
 end

--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -1,30 +1,32 @@
 class V1::SubmissionEntriesController < ApplicationController
+  deserializable_resource :submission_entry, only: [:create]
+
   def create
-    @entry = initialize_submission_entry
+    entry = initialize_submission_entry
 
-    @entry.source = submission_entry_params[:source]
-    @entry.data = submission_entry_params[:data]
+    entry.source = submission_entry_params[:source]
+    entry.data = submission_entry_params[:data]
 
-    if @entry.save
-      render json: @entry, status: :created
+    if entry.save
+      render jsonapi: entry, status: :created
     else
-      render json: @entry.errors, status: :bad_request
+      render jsonapi_errors: entry.errors, status: :bad_request
     end
   end
 
   private
 
   def initialize_submission_entry
-    if submission_entry_params[:file_id].present?
-      file = SubmissionFile.find(submission_entry_params[:file_id])
+    if params[:file_id].present?
+      file = SubmissionFile.find(params[:file_id])
       file.entries.new(submission: file.submission)
     else
-      submission = Submission.find(submission_entry_params[:submission_id])
+      submission = Submission.find(params[:submission_id])
       submission.entries.new
     end
   end
 
   def submission_entry_params
-    params.permit(:file_id, :submission_id, source: {}, data: {})
+    params.require(:submission_entry).permit(source: {}, data: {})
   end
 end

--- a/app/controllers/v1/submission_files_controller.rb
+++ b/app/controllers/v1/submission_files_controller.rb
@@ -1,13 +1,12 @@
 class V1::SubmissionFilesController < ApplicationController
   def create
     submission = Submission.find(submission_file_params[:submission_id])
+    submission_file = submission.files.new
 
-    @submission_file = submission.files.new
-
-    if @submission_file.save
-      render json: @submission_file, status: :created
+    if submission_file.save
+      render jsonapi: submission_file, status: :created
     else
-      render json: @submission_file.errors, status: :bad_request
+      render jsonapi: submission_file.errors, status: :bad_request
     end
   end
 

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -3,18 +3,18 @@ class V1::SubmissionsController < ApplicationController
     framework = Framework.find(submission_params[:framework_id])
     supplier = Supplier.find(submission_params[:supplier_id])
 
-    @submission = Submission.new(framework: framework, supplier: supplier)
+    submission = Submission.new(framework: framework, supplier: supplier)
 
-    if @submission.save
-      render json: @submission, status: :created
+    if submission.save
+      render jsonapi: submission, status: :created
     else
-      render json: @submission.errors, status: :bad_request
+      render jsonapi_errors: submission.errors, status: :bad_request
     end
   end
 
   private
 
   def submission_params
-    params.permit(:framework_id, :supplier_id, :source, :data)
+    params.permit(:framework_id, :supplier_id)
   end
 end

--- a/app/controllers/v1/suppliers_controller.rb
+++ b/app/controllers/v1/suppliers_controller.rb
@@ -1,5 +1,5 @@
 class V1::SuppliersController < ApplicationController
   def index
-    @suppliers = Supplier.all
+    render jsonapi: Supplier.all
   end
 end

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -1,6 +1,7 @@
 class V1::TasksController < ApplicationController
   def create
     @task = Task.new(task_params)
+
     if @task.save
       render json: @task, status: :created
     else
@@ -9,11 +10,13 @@ class V1::TasksController < ApplicationController
   end
 
   def index
-    @tasks = if params[:status].present?
-               Task.where(status: params[:status])
-             else
-               Task.all
-             end
+    tasks = if params.dig(:filter, :status)
+              Task.where(status: params.dig(:filter, :status))
+            else
+              Task.all
+            end
+
+    render jsonapi: tasks
   end
 
   def complete

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -1,11 +1,13 @@
 class V1::TasksController < ApplicationController
-  def create
-    @task = Task.new(task_params)
+  deserializable_resource :task, only: [:create]
 
-    if @task.save
-      render json: @task, status: :created
+  def create
+    task = Task.new(task_params)
+
+    if task.save
+      render jsonapi: task, status: :created
     else
-      render json: @task.errors, status: :bad_request
+      render jsonapi_errors: task.errors, status: :bad_request
     end
   end
 
@@ -27,6 +29,6 @@ class V1::TasksController < ApplicationController
   private
 
   def task_params
-    params.permit(:status)
+    params.require(:task).permit(:status)
   end
 end

--- a/app/deserializable/deserializable_submission_entry.rb
+++ b/app/deserializable/deserializable_submission_entry.rb
@@ -1,0 +1,4 @@
+class DeserializableSubmissionEntry < JSONAPI::Deserializable::Resource
+  attribute :source
+  attribute :data
+end

--- a/app/deserializable/deserializable_task.rb
+++ b/app/deserializable/deserializable_task.rb
@@ -1,0 +1,3 @@
+class DeserializableTask < JSONAPI::Deserializable::Resource
+  attribute :status
+end

--- a/app/serializable/serializable_agreement.rb
+++ b/app/serializable/serializable_agreement.rb
@@ -1,0 +1,5 @@
+class SerializableAgreement < JSONAPI::Serializable::Resource
+  type 'agreements'
+
+  attributes :framework_id, :supplier_id
+end

--- a/app/serializable/serializable_framework.rb
+++ b/app/serializable/serializable_framework.rb
@@ -1,0 +1,5 @@
+class SerializableFramework < JSONAPI::Serializable::Resource
+  type 'frameworks'
+
+  attributes :short_name, :name
+end

--- a/app/serializable/serializable_submission.rb
+++ b/app/serializable/serializable_submission.rb
@@ -1,0 +1,5 @@
+class SerializableSubmission < JSONAPI::Serializable::Resource
+  type 'submissions'
+
+  attributes :framework_id, :supplier_id
+end

--- a/app/serializable/serializable_submission_entry.rb
+++ b/app/serializable/serializable_submission_entry.rb
@@ -1,0 +1,9 @@
+class SerializableSubmissionEntry < JSONAPI::Serializable::Resource
+  type 'submission_entries'
+
+  attribute :submission_id
+  attribute :submission_file_id
+
+  attribute :source
+  attribute :data
+end

--- a/app/serializable/serializable_submission_file.rb
+++ b/app/serializable/serializable_submission_file.rb
@@ -1,0 +1,5 @@
+class SerializableSubmissionFile < JSONAPI::Serializable::Resource
+  type 'submission_files'
+
+  attribute :submission_id
+end

--- a/app/serializable/serializable_supplier.rb
+++ b/app/serializable/serializable_supplier.rb
@@ -1,0 +1,5 @@
+class SerializableSupplier < JSONAPI::Serializable::Resource
+  type 'suppliers'
+
+  attributes :name
+end

--- a/app/serializable/serializable_task.rb
+++ b/app/serializable/serializable_task.rb
@@ -1,0 +1,5 @@
+class SerializableTask < JSONAPI::Serializable::Resource
+  type 'tasks'
+
+  attributes :status
+end

--- a/app/views/v1/frameworks/index.json.jbuilder
+++ b/app/views/v1/frameworks/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.frameworks @frameworks, :id, :short_name, :name

--- a/app/views/v1/frameworks/show.json.jbuilder
+++ b/app/views/v1/frameworks/show.json.jbuilder
@@ -1,4 +1,0 @@
-json.name @framework.name
-json.short_name @framework.short_name
-
-json.lots @framework.lots

--- a/app/views/v1/suppliers/index.json.jbuilder
+++ b/app/views/v1/suppliers/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.suppliers @suppliers

--- a/app/views/v1/tasks/index.json.jbuilder
+++ b/app/views/v1/tasks/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.tasks @tasks

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,7 @@ require 'rails'
 require 'active_model/railtie'
 require 'active_job/railtie'
 require 'active_record/railtie'
-require 'active_storage/engine'
+# require 'active_storage/engine'
 require 'action_controller/railtie'
 # require "action_mailer/railtie"
 require 'action_view/railtie'

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -27,9 +27,6 @@ Rails.application.configure do
     config.cache_store = :null_store
   end
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
-
   # Print deprecation notices to the Rails logger.
   config.active_support.deprecation = :log
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,9 +29,6 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Sendfile' # for Apache
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
-  # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :local
-
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   # config.force_ssl = true
 

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -28,9 +28,6 @@ Rails.application.configure do
   # Disable request forgery protection in test environment.
   config.action_controller.allow_forgery_protection = false
 
-  # Store uploaded files on the local file system in a temporary directory
-  config.active_storage.service = :test
-
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,7 +4,7 @@ Rails.application.routes.draw do
 
   namespace :v1, defaults: { format: :json } do
     resources :frameworks, only: %i[index show]
-    resources :suppliers, only: %i[index show]
+    resources :suppliers, only: %i[index]
     resources :agreements, only: %i[create]
     resources :submissions, only: %i[create] do
       resources :files, only: %i[create], controller: 'submission_files'

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -5,6 +5,7 @@ require File.expand_path('../config/environment', __dir__)
 # Prevent database truncation if the environment is production
 abort('The Rails environment is running in production mode!') if Rails.env.production?
 require 'rspec/rails'
+require 'jsonapi/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
 # Requires supporting ruby files with custom matchers and macros, etc, in
@@ -27,6 +28,7 @@ Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
+  config.include JSONAPI::RSpec
   config.include RequestHelpers, type: :request
 
   # Remove this line if you're not using ActiveRecord or ActiveRecord fixtures

--- a/spec/requests/v1/agreements_spec.rb
+++ b/spec/requests/v1/agreements_spec.rb
@@ -8,11 +8,13 @@ RSpec.describe '/v1' do
 
       post "/v1/agreements?framework_id=#{framework.id}&supplier_id=#{supplier.id}"
 
-      expect(response).to be_successful
+      expect(response).to have_http_status(:created)
 
       agreement = Agreement.first
-      expect(agreement.framework).to eql framework
-      expect(agreement.supplier).to eql supplier
+
+      expect(json['data']).to have_id(agreement.id)
+      expect(json['data']).to have_attribute(:framework_id).with_value(framework.id)
+      expect(json['data']).to have_attribute(:supplier_id).with_value(supplier.id)
     end
   end
 end

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -6,12 +6,23 @@ RSpec.describe '/v1' do
       file = FactoryBot.create(:submission_file)
 
       params = {
-        source: { sheet: 'InvoicesReceived', row: 42 },
-        data: { test: 'test' }
+        data: {
+          type: 'submission_entries',
+          attributes: {
+            source: {
+              sheet: 'InvoicesReceived',
+              row: 42
+            },
+            data: {
+              test: 'test'
+            }
+          }
+        }
       }
 
       headers = {
-        'CONTENT_TYPE': 'application/json'
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
       }
 
       post "/v1/files/#{file.id}/entries", params: params.to_json, headers: headers
@@ -20,21 +31,34 @@ RSpec.describe '/v1' do
 
       entry = SubmissionEntry.first
 
-      expect(json['id']).to eql entry.id
-      expect(json['source']['sheet']).to eql 'InvoicesReceived'
-      expect(json['source']['row']).to eql 42
-      expect(json['data']['test']).to eql 'test'
+      expect(json['data']).to have_id(entry.id)
+
+      expect(json['data']).to have_attribute(:submission_file_id).with_value(file.id)
+      expect(json['data']).to have_attribute(:submission_id).with_value(file.submission.id)
+
+      expect(json.dig('data', 'attributes', 'source', 'sheet')).to eql 'InvoicesReceived'
+      expect(json.dig('data', 'attributes', 'source', 'row')).to eql 42
+      expect(json.dig('data', 'attributes', 'data', 'test')).to eql 'test'
     end
 
     it 'returns an error if the "data" parameter is omitted' do
       file = FactoryBot.create(:submission_file)
 
       params = {
-        source: { sheet: 'Orders', row: 1 }
+        data: {
+          type: 'submission_entries',
+          attributes: {
+            source: {
+              sheet: 'Orders',
+              row: 1
+            }
+          }
+        }
       }
 
       headers = {
-        'CONTENT_TYPE': 'application/json'
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
       }
 
       post "/v1/files/#{file.id}/entries", params: params.to_json, headers: headers

--- a/spec/requests/v1/frameworks_spec.rb
+++ b/spec/requests/v1/frameworks_spec.rb
@@ -26,15 +26,11 @@ RSpec.describe '/v1' do
 
       expect(response).to be_successful
 
-      expected = {
-        name: 'Cheese Board 8',
-        short_name: 'cboard8'
-      }
-
-      expect(response.body).to include_json(expected)
+      expect(json['data']).to have_attribute(:name).with_value('Cheese Board 8')
+      expect(json['data']).to have_attribute(:short_name).with_value('cboard8')
     end
 
-    it 'includes the list of lots on that framework' do
+    xit 'includes the list of lots on that framework' do
       framework = FactoryBot.create(:framework, name: 'Cheese Board 8', short_name: 'cboard8')
 
       FactoryBot.create(:framework_lot, number: '1a', framework: framework)

--- a/spec/requests/v1/frameworks_spec.rb
+++ b/spec/requests/v1/frameworks_spec.rb
@@ -29,27 +29,5 @@ RSpec.describe '/v1' do
       expect(json['data']).to have_attribute(:name).with_value('Cheese Board 8')
       expect(json['data']).to have_attribute(:short_name).with_value('cboard8')
     end
-
-    xit 'includes the list of lots on that framework' do
-      framework = FactoryBot.create(:framework, name: 'Cheese Board 8', short_name: 'cboard8')
-
-      FactoryBot.create(:framework_lot, number: '1a', framework: framework)
-      FactoryBot.create(:framework_lot, number: '1b', framework: framework)
-
-      get "/v1/frameworks/#{framework.id}"
-
-      expect(response).to be_successful
-
-      expected = {
-        name: 'Cheese Board 8',
-        short_name: 'cboard8',
-        lots: [
-          { number: '1a' },
-          { number: '1b' }
-        ]
-      }
-
-      expect(response.body).to include_json(expected)
-    end
   end
 end

--- a/spec/requests/v1/frameworks_spec.rb
+++ b/spec/requests/v1/frameworks_spec.rb
@@ -9,16 +9,12 @@ RSpec.describe '/v1' do
       get '/v1/frameworks'
 
       expect(response).to be_successful
-      expect(json['frameworks'].size).to eql 2
 
-      expected = {
-        frameworks: [
-          { name: 'Cheese Board 8', short_name: 'cboard8' },
-          { name: 'Baked Goods Supply Services', short_name: 'RM0000' }
-        ]
-      }
+      expect(json['data'][0]).to have_attribute(:name).with_value('Cheese Board 8')
+      expect(json['data'][0]).to have_attribute(:short_name).with_value('cboard8')
 
-      expect(response.body).to include_json(expected)
+      expect(json['data'][1]).to have_attribute(:name).with_value('Baked Goods Supply Services')
+      expect(json['data'][1]).to have_attribute(:short_name).with_value('RM0000')
     end
   end
 

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -27,8 +27,9 @@ RSpec.describe '/v1' do
       expect(response).to have_http_status(:created)
 
       file = SubmissionFile.first
-      expect(json['id']).to eql file.id
-      expect(json['submission_id']).to eql submission.id
+
+      expect(json['data']).to have_id(file.id)
+      expect(json['data']).to have_attribute(:submission_id).with_value(submission.id)
     end
   end
 

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -38,12 +38,23 @@ RSpec.describe '/v1' do
       submission = FactoryBot.create(:submission)
 
       params = {
-        source: { sheet: 'InvoicesReceived', row: 42 },
-        data: { test: 'test' }
+        data: {
+          type: 'submission_entries',
+          attributes: {
+            source: {
+              sheet: 'InvoicesReceived',
+              row: 42
+            },
+            data: {
+              test: 'test'
+            }
+          }
+        }
       }
 
       headers = {
-        'CONTENT_TYPE': 'application/json'
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
       }
 
       post "/v1/submissions/#{submission.id}/entries", params: params.to_json, headers: headers
@@ -52,13 +63,14 @@ RSpec.describe '/v1' do
 
       entry = SubmissionEntry.first
 
-      expect(json['id']).to eql entry.id
-      expect(json['submission_id']).to eql submission.id
-      expect(json['submission_file_id']).to be_nil
+      expect(json['data']).to have_id(entry.id)
 
-      expect(json['source']['sheet']).to eql 'InvoicesReceived'
-      expect(json['source']['row']).to eql 42
-      expect(json['data']['test']).to eql 'test'
+      expect(json['data']).to have_attribute(:submission_id).with_value(submission.id)
+      expect(json['data']).to have_attribute(:submission_file_id).with_value(nil)
+
+      expect(json.dig('data', 'attributes', 'source', 'sheet')).to eql 'InvoicesReceived'
+      expect(json.dig('data', 'attributes', 'source', 'row')).to eql 42
+      expect(json.dig('data', 'attributes', 'data', 'test')).to eql 'test'
     end
   end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -11,7 +11,10 @@ RSpec.describe '/v1' do
       expect(response).to have_http_status(:created)
 
       submission = Submission.first
-      expect(json['id']).to eql submission.id
+
+      expect(json['data']).to have_id(submission.id)
+      expect(json['data']).to have_attribute(:framework_id).with_value(framework.id)
+      expect(json['data']).to have_attribute(:supplier_id).with_value(supplier.id)
     end
   end
 

--- a/spec/requests/v1/suppliers_spec.rb
+++ b/spec/requests/v1/suppliers_spec.rb
@@ -10,14 +10,8 @@ RSpec.describe '/v1' do
 
       expect(response).to be_successful
 
-      expected = {
-        suppliers: [
-          { name: 'A1 Cakes Ltd' },
-          { name: 'Bakery Plus' }
-        ]
-      }
-
-      expect(response.body).to include_json(expected)
+      expect(json['data'][0]).to have_attribute(:name).with_value('A1 Cakes Ltd')
+      expect(json['data'][1]).to have_attribute(:name).with_value('Bakery Plus')
     end
   end
 end

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -4,11 +4,17 @@ RSpec.describe '/v1' do
   describe 'POST /tasks' do
     it 'creates a new task' do
       params = {
-        status: 'test'
+        data: {
+          type: 'tasks',
+          attributes: {
+            status: 'test'
+          }
+        }
       }
 
       headers = {
-        'CONTENT_TYPE': 'application/json'
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
       }
 
       post '/v1/tasks', params: params.to_json, headers: headers
@@ -16,17 +22,23 @@ RSpec.describe '/v1' do
       expect(response).to have_http_status(:created)
 
       task = Task.first
-
-      expect(json['id']).to eql task.id
-      expect(json['status']).to eql task.status
+      expect(json['data']).to have_id(task.id)
+      expect(json['data']).to have_attribute(:status).with_value('test')
     end
 
-    it 'returns an error if the status parameter is ommited' do
-      params = {}
+    it 'returns an error if the status parameter is omitted' do
+      params = {
+        data: {
+          type: 'tasks',
+          attributes: {}
+        }
+      }
 
       headers = {
-        'CONTENT_TYPE': 'application/json'
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
       }
+
       post '/v1/tasks', params: params.to_json, headers: headers
 
       expect(response).to have_http_status(:bad_request)

--- a/spec/requests/v1/tasks_spec.rb
+++ b/spec/requests/v1/tasks_spec.rb
@@ -42,38 +42,30 @@ RSpec.describe '/v1' do
       get '/v1/tasks'
 
       expect(response).to be_successful
-      expect(json['tasks'].size).to eql 3
 
-      expected = {
-        tasks: [
-          { id: task1.id, status: 'test' },
-          { id: task2.id, status: 'ready' },
-          { id: task3.id, status: 'in progress' }
-        ]
-      }
+      expect(json['data'][0]).to have_id(task1.id)
+      expect(json['data'][0]).to have_attribute(:status).with_value('test')
 
-      expect(response.body).to include_json(expected)
+      expect(json['data'][1]).to have_id(task2.id)
+      expect(json['data'][1]).to have_attribute(:status).with_value('ready')
+
+      expect(json['data'][2]).to have_id(task3.id)
+      expect(json['data'][2]).to have_attribute(:status).with_value('in progress')
     end
   end
 
-  describe 'GET /tasks?status=' do
+  describe 'GET /tasks?filter[status]=' do
     it 'returns a filtered list of tasks matching the statue value in the URL' do
       FactoryBot.create(:task, status: 'test')
       FactoryBot.create(:task, status: 'ready')
       FactoryBot.create(:task, status: 'in progress')
 
-      get '/v1/tasks?status=test'
+      get '/v1/tasks?filter[status]=ready'
 
       expect(response).to be_successful
-      expect(json['tasks'].size).to eql 1
 
-      expected = {
-        tasks: [
-          { status: 'test' }
-        ]
-      }
-
-      expect(response.body).to include_json(expected)
+      expect(json['data'].size).to eql 1
+      expect(json['data'][0]).to have_attribute(:status).with_value('ready')
     end
   end
 


### PR DESCRIPTION
This replaces the majority of the existing endpoints with very basic JSON API ones. It's lacking pagination and proper error handling for now, but it's a good start that we can build on.

For the time being I've omitted the `/v1/events/*` endpoints as I didn't want to break the existing event logging between the frontend and the API application for now.

I've also ignored the `/v1/tasks/:id/complete`, as I think JSON API may need a more RESTful approach to this.

## Experimental API Client

There's an [experimental WIP branch](https://github.com/Crown-Commercial-Service/DataSubmissionService/tree/wip/jsonapi-client) that implements a simple client using the `jsonapi-consumer` gem.

The consumer creates an ActiveRecord-like interface to the API, e.g.

- `API::Supplier.all` - get all suppliers
- `API::Task.where(status: 'completed').all` - get all tasks with the status of 'completed'
- `API::Task.create(status: 'new')` - create a new task with the status of 'new'