### PR TITLE
(115) Temporary endpoint for updating submission entries

### DIFF
--- a/app/controllers/v1/submission_entries_controller.rb
+++ b/app/controllers/v1/submission_entries_controller.rb
@@ -14,6 +14,13 @@ class V1::SubmissionEntriesController < ApplicationController
     end
   end
 
+  def update
+    submission_file = SubmissionFile.find(params[:file_id])
+    submission_file.entries.find(params[:id])
+
+    head :no_content
+  end
+
   def show
     submission_file = SubmissionFile.find(params[:file_id])
     entry = submission_file.entries.find(params[:id])

--- a/app/controllers/v1/submissions_controller.rb
+++ b/app/controllers/v1/submissions_controller.rb
@@ -1,4 +1,6 @@
 class V1::SubmissionsController < ApplicationController
+  deserializable_resource :submission, only: [:update]
+
   def create
     framework = Framework.find(submission_params[:framework_id])
     supplier = Supplier.find(submission_params[:supplier_id])
@@ -12,9 +14,24 @@ class V1::SubmissionsController < ApplicationController
     end
   end
 
+  def update
+    submission = Submission.find(params[:id])
+    submission.levy = update_submission_params[:levy] * 100
+
+    if submission.save
+      head :no_content
+    else
+      render jsonapi_errors: submission.errors, status: :bad_request
+    end
+  end
+
   private
 
   def submission_params
     params.permit(:framework_id, :supplier_id)
+  end
+
+  def update_submission_params
+    params.require(:submission).permit(:levy)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,7 +6,7 @@ Rails.application.routes.draw do
     resources :frameworks, only: %i[index show]
     resources :suppliers, only: %i[index]
     resources :agreements, only: %i[create]
-    resources :submissions, only: %i[create] do
+    resources :submissions, only: %i[create update] do
       resources :files, only: %i[create update], controller: 'submission_files'
       resources :entries, only: %i[create], controller: 'submission_entries'
     end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,7 @@ Rails.application.routes.draw do
     end
 
     resources :files, only: [] do
-      resources :entries, only: %i[create show], controller: 'submission_entries'
+      resources :entries, only: %i[show create update], controller: 'submission_entries'
     end
 
     namespace :events do

--- a/db/migrate/20180702145630_add_levy_to_submission.rb
+++ b/db/migrate/20180702145630_add_levy_to_submission.rb
@@ -1,0 +1,5 @@
+class AddLevyToSubmission < ActiveRecord::Migration[5.2]
+  def change
+    add_column :submissions, :levy, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_06_11_171947) do
+ActiveRecord::Schema.define(version: 2018_07_02_145630) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -74,6 +74,7 @@ ActiveRecord::Schema.define(version: 2018_06_11_171947) do
   create_table "submissions", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|
     t.uuid "framework_id", null: false
     t.uuid "supplier_id", null: false
+    t.integer "levy"
     t.index ["framework_id"], name: "index_submissions_on_framework_id"
     t.index ["supplier_id"], name: "index_submissions_on_supplier_id"
   end

--- a/spec/requests/v1/files_spec.rb
+++ b/spec/requests/v1/files_spec.rb
@@ -91,4 +91,31 @@ RSpec.describe '/v1' do
       expect(json.dig('data', 'attributes', 'data', 'test')).to eql 'test'
     end
   end
+
+  describe 'PATCH /files/:file_id/entries/:id' do
+    it 'updates the given entry' do
+      file = FactoryBot.create(:submission_file)
+      entry = FactoryBot.create(:submission_entry,
+                                submission_file: file,
+                                data: { test: 'test' })
+
+      params = {
+        data: {
+          type: 'submission_entries',
+          attributes: {
+            valid: true
+          }
+        }
+      }
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      patch "/v1/files/#{file.id}/entries/#{entry.id}", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:no_content)
+    end
+  end
 end

--- a/spec/requests/v1/submissions_spec.rb
+++ b/spec/requests/v1/submissions_spec.rb
@@ -18,6 +18,32 @@ RSpec.describe '/v1' do
     end
   end
 
+  describe 'PATCH /submission/:submission_id' do
+    it 'updates the given submission' do
+      submission = FactoryBot.create(:submission)
+
+      params = {
+        data: {
+          type: 'submissions',
+          attributes: {
+            levy: 42.50
+          }
+        }
+      }
+
+      headers = {
+        'Content-Type': 'application/vnd.api+json',
+        'Accept': 'application/vnd.api+json'
+      }
+
+      patch "/v1/submissions/#{submission.id}", params: params.to_json, headers: headers
+
+      expect(response).to have_http_status(:no_content)
+
+      expect(submission.reload.levy).to eql 4250
+    end
+  end
+
   describe 'POST /submissions/:submission_id/files' do
     it 'creates a new submission file and returns its id' do
       submission = FactoryBot.create(:submission)


### PR DESCRIPTION
NB: Currently `PATCH /v1/files/:file_id/entries/:entry_id` does nothing beyond checking that the requested `SubmissionFile` and `SubmissionEntry` exist, and then returning `HTTP 204 No Content`.