### PR TITLE
(1156) Bump Python to v3.7.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN YARN_VERSION=1.17.3 \
 
 COPY requirements.txt $INSTALL_PATH/requirements.txt
 # This should be kept in sync with the version specified in runtime.txt
-ENV PYTHON_VERSION 3.7.2
+ENV PYTHON_VERSION 3.7.4
 RUN wget https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz \
     && tar -xf Python-${PYTHON_VERSION}.tgz \
     && cd Python-${PYTHON_VERSION} \

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.7.2
+python-3.7.4


### PR DESCRIPTION
The version we were previously using is no longer available on GPaaS, so any infrastructure changes were causing the Sidekiq instance to fail to build.
