### PR TITLE
(1188) Handle ActiveJob::DeserializationError nicely

### DIFF
--- a/app/jobs/submission_ingestion_job.rb
+++ b/app/jobs/submission_ingestion_job.rb
@@ -3,6 +3,11 @@ class SubmissionIngestionJob < ApplicationJob
 
   queue_as :ingest
 
+  # discard_on ActiveJob::DeserializationError do |job, exception|
+  #   Rollbar.error('ActiveJob::DeserializationError in SubmissionIngestionJob', submission_file: job.arguments.first)
+  #   handle_unretryable_job_failure(job, exception)
+  # end
+
   discard_on(Ingest::Loader::MissingColumns) do |job, exception|
     handle_unretryable_job_failure(job, exception)
   end

--- a/spec/jobs/submission_ingestion_job_spec.rb
+++ b/spec/jobs/submission_ingestion_job_spec.rb
@@ -12,5 +12,21 @@ RSpec.describe SubmissionIngestionJob do
         end.to raise_error(SubmissionIngestionJob::IngestFailed)
       end
     end
+
+    context 'the submission file has not persisted' do
+      let(:submission_file) do
+        build(:submission_file, submission: create(:submission))
+      end
+
+      it 'reports to Rollbar and discards the job' do
+        allow_any_instance_of(Ingest::Orchestrator).to receive(:perform).and_return(true)
+
+        expect_any_instance_of(SubmissionIngestionJob).not_to receive(:retry_job)
+
+        expect do
+          SubmissionIngestionJob.new.perform(submission_file)
+        end.to raise_error(ActiveJob::DeserializationError)
+      end
+    end
   end
 end


### PR DESCRIPTION
Occasionally, a submission file upload will fail, but will still enqueue a `SubmissionIngestionJob`. This will raise an `ActiveJob::DeserializationError` and will keep retrying, even though the file is never going to appear.

For now, let's catch these exceptions and prevent the job from retrying (and failing) endlessly. When we have more time, we should see if we can either fix the underlying problem (file upload failure) or tell the user when it happens.