### PR TITLE
(Zendesk #11247) Prevent exceptions when UserImportJob fails

### DIFF
--- a/app/jobs/user_import_job.rb
+++ b/app/jobs/user_import_job.rb
@@ -3,22 +3,37 @@ require 'aws-sdk-s3'
 
 class UserImportJob < ApplicationJob
   retry_on Aws::S3::Errors::ServiceError
-  discard_on Import::Users::InvalidSalesforceId
+
+  discard_on Import::Users::InvalidSalesforceId do |job, exception|
+    handle_unretryable_job_failure(job, exception)
+  end
+
+  discard_on Aws::S3::Errors::NoSuchKey do |job, exception|
+    handle_unretryable_job_failure(job, exception)
+  end
 
   def perform(user_list_key)
+    Rails.logger.info "Bulk user import started for: #{user_list_key}"
+
     temp_file = Tempfile.new(user_list_key)
     temp_file.binmode
 
-    s3_client.get_object({ bucket: bucket, key: user_list_key }, target: temp_file)
+    begin
+      s3_client.get_object({ bucket: bucket, key: user_list_key }, target: temp_file)
+      Import::Users.new(temp_file).run
+    ensure
+      temp_file.close
+      temp_file.unlink
+    end
 
-    Rollbar.info("Bulk user import started for: #{user_list_key}")
-
-    Import::Users.new(temp_file).run
-    Rollbar.info("Bulk user import completed for: #{user_list_key}")
-  ensure
-    temp_file.close
-    temp_file.unlink
+    Rails.logger.info "Bulk user import completed for: #{user_list_key}"
     s3_client.delete_object(bucket: bucket, key: user_list_key)
+  end
+
+  def self.handle_unretryable_job_failure(job, exception)
+    user_list_key = job.arguments.first
+    Rollbar.info "Bulk user import failed for '#{user_list_key}': #{exception.message}"
+    true
   end
 
   private


### PR DESCRIPTION
Despite UserImportJob being configured to discard a job on an `InvalidSaleforceId` exception, it kept retrying forever despite this being a hard fail state.

Having looked at the production logs, it's possibly more to do with the file being deleted from the S3 bucket whether or not the file was processed successfully. I found at least one occasion where the call to S3 to fetch the file failed (raising an Aws::S3::Errors::ServiceError) exception, but the subsequent `delete_object` call passed, leaving the job to retry with no file to process.

I've therefore reorganised the UserImportJob to only delete the file after the importer finishes successfully. If the file legitimately does not exist (due to S3 upload failure, for example) we additionally discard the job when an `Aws::S3::Errors::NoSuchKey` exception occurs.

Finally, I'm only raising failures to Rollbar - the Rails logger is the correct place for informational messages when the job succeeds.

Replaces: https://github.com/dxw/DataSubmissionServiceAPI/pull/610