### PR TITLE
Changed link for endpoint documentation in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ default user full name, either of which can be changed at login if you wish.
 
 ## API Endpoints
 
-A [full list of the API endpoints](endpoints.md) is available in a separate document.
+A [full list of the API endpoints](https://app.swaggerhub.com/apis/Crown-Commercial/RMI/1.0.0#/info) is available in SwaggerHub.
 
 ## Onboarding suppliers and users
 


### PR DESCRIPTION
## Description
Endpoint documentation link in README now directs to new SwaggerHub docs. Related to: https://crowncommercialservice.atlassian.net/jira/software/projects/RMI/boards/94?selectedIssue=RMI-241

## Why was the change made?
Previous link was for a non-existent document

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] This change requires a documentation update

## How was the change tested?
N/A
