### PR TITLE
Feature/rmi 32 restrict template upload to excel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Work required for RMI-242
 - Bump rails from 5.2.4.4 to 5.2.4.3
 - [Security] Bump actionview dependency from 5.2.4.3 to 5.2.4.4
+- Fix: templates now keep their original file extension
+- Admin template uploads restricted to .xls and .xlsx files
 
 ## [release-109] - 2020-11-09
 

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -42,6 +42,7 @@ class Admin::FrameworksController < AdminController
   def update
     if params.dig(:framework, :template_file).present?
       return redirect_to admin_framework_path, alert: 'Uploaded file must be an excel file' unless excel_file?
+
       @framework.update!(framework_params)
       flash[:success] = 'Framework saved successfully.'
     else
@@ -86,7 +87,7 @@ class Admin::FrameworksController < AdminController
     uploaded_file = params.require(:framework).require(:template_file)
     file_extension = File.extname(uploaded_file.original_filename)
 
-    (file_extension == '.xls' || file_extension == '.xlsx') && 
+    ['.xls', '.xlsx'].include?(file_extension) &&
       ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'].include?(uploaded_file.content_type)
   end
 end

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -86,8 +86,8 @@ class Admin::FrameworksController < AdminController
   def excel_file?
     uploaded_file = params.require(:framework).require(:template_file)
     file_extension = File.extname(uploaded_file.original_filename)
+    mime_types = ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel']
 
-    ['.xls', '.xlsx'].include?(file_extension) &&
-      ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'].include?(uploaded_file.content_type)
+    ['.xls', '.xlsx'].include?(file_extension) && mime_types.include?(uploaded_file.content_type)
   end
 end

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -41,6 +41,7 @@ class Admin::FrameworksController < AdminController
 
   def update
     if params.dig(:framework, :template_file).present?
+      return redirect_to admin_framework_path, alert: 'Uploaded file must be an excel file' unless excel_file?
       @framework.update!(framework_params)
       flash[:success] = 'Framework saved successfully.'
     else
@@ -79,5 +80,13 @@ class Admin::FrameworksController < AdminController
 
   def framework_params
     params.require(:framework).permit(:definition_source, :template_file)
+  end
+
+  def excel_file?
+    uploaded_file = params.require(:framework).require(:template_file)
+    file_extension = File.extname(uploaded_file.original_filename)
+
+    (file_extension == '.xls' || file_extension == '.xlsx') && 
+      ['application/vnd.openxmlformats-officedocument.spreadsheetml.sheet', 'application/vnd.ms-excel'].include?(uploaded_file.content_type)
   end
 end


### PR DESCRIPTION
## Description
Restricted template upload to agreed file types
https://crowncommercialservice.atlassian.net/browse/RMI-32

## Why was the change made?
Put in a check for file type in frameworks controller and an alert in case upload file is not .xls or .xlsx

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Tested locally by uploading different files types and checking response
