### PR TITLE
Feature/rmi 243 auto fail submissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [release-111] - 2020-11-26
 
 - RMI-275: Add to travis.yml and deploy-app.sh to accomodate and add Preproduction to the Travis/Github infrastructure.
-- RMI-274: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method.
+- RMI-243: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method.
 
 ## [release-110] - 2020-11-11
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Change Log
 
-## [release-111] - 2020-11-24
+## [release-111] - 2020-11-26
 
 - RMI-275: Add to travis.yml and deploy-app.sh to accomodate and add Preproduction to the Travis/Github infrastructure.
+- RMI-274: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method.
 
 ## [release-110] - 2020-11-11
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,7 +1,9 @@
 class Admin::UsersController < AdminController
   def index
     @users = User.search(params[:search]).page(params[:page])
-    submissions_stuck = Submission.joins(:task).where("aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.now - 1.day)
+    submissions_stuck = Submission.joins(:task).where(
+      "aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.zone.now - 1.day
+    )
     submissions_stuck.each{ |s| s.update!(aasm_state: :ingest_failed) }
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,7 +4,7 @@ class Admin::UsersController < AdminController
     submissions_stuck = Submission.joins(:task).where(
       "aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.zone.now - 1.day
     )
-    submissions_stuck.each{ |s| s.update!(aasm_state: :ingest_failed) }
+    submissions_stuck.each { |s| s.update!(aasm_state: :ingest_failed) }
   end
 
   def show

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,6 +1,8 @@
 class Admin::UsersController < AdminController
   def index
     @users = User.search(params[:search]).page(params[:page])
+    submissions_stuck = Submission.joins(:task).where("aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.now - 1.day)
+    submissions_stuck.each{ |s| s.update!(aasm_state: :ingest_failed) }
   end
 
   def show


### PR DESCRIPTION
## Description
RMI-243

## Why was the change made?
Prior to this feature, dev's would have to manually ssh into an environment and automatically fail any ingests stuck in processing for longer than 24hrs. This removes that manual step so it is automatic on the sign in landing page.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

 [X] This change requires a documentation update

## How was the change tested?
Locally running I carried out the lines of code to some ingests that were stuck. Also used the same lines in staging rails console, with some further stuck ingests.
