### PR TITLE
Fix/RMI-243-Add-conditional-and-comment

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,7 +79,7 @@ Metrics/AbcSize:
         - 'lib/console_helpers.rb'
 
 Metrics/LineLength:
-    Max: 180
+    Max: 120
     Exclude:
         - 'app/models/framework/definition/**/*'
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -79,7 +79,7 @@ Metrics/AbcSize:
         - 'lib/console_helpers.rb'
 
 Metrics/LineLength:
-    Max: 120
+    Max: 180
     Exclude:
         - 'app/models/framework/definition/**/*'
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 ## [release-111] - 2020-11-26
 
 - RMI-275: Add to travis.yml and deploy-app.sh to accomodate and add Preproduction to the Travis/Github infrastructure.
-- RMI-243: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method.
+- RMI-243: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method. Also add conditional and comment.
 
 ## [release-110] - 2020-11-11
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -4,8 +4,9 @@ class Admin::UsersController < AdminController
     # The following block (Lines 8 to 11), will check for stuck submissions in 'processing' longer than 24hrs.
     # These submissions are collated into array 'submissions_stuck'. If non-empty, this array is then looped
     # through to update them as 'failed' (in a database query), to then be resubmitted by a supplier (or not).
-    submissions_stuck = Submission.joins(:task).where("aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.zone.now - 1.day)
     # rubocop:disable Metrics/LineLength
+    submissions_stuck = Submission.joins(:task).where("aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.zone.now - 1.day)
+    # rubocop:enable Metrics/LineLength
     submissions_stuck.each { |s| s.update!(aasm_state: :ingest_failed) } if submissions_stuck.length.positive?
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -5,6 +5,7 @@ class Admin::UsersController < AdminController
     # These submissions are collated into array 'submissions_stuck'. If non-empty, this array is then looped
     # through to update them as 'failed' (in a database query), to then be resubmitted by a supplier (or not).
     submissions_stuck = Submission.joins(:task).where("aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.zone.now - 1.day)
+    # rubocop:disable Metrics/LineLength
     submissions_stuck.each { |s| s.update!(aasm_state: :ingest_failed) } if submissions_stuck.length.positive?
   end
 

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,10 +1,11 @@
 class Admin::UsersController < AdminController
   def index
     @users = User.search(params[:search]).page(params[:page])
-    submissions_stuck = Submission.joins(:task).where(
-      "aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.zone.now - 1.day
-    )
-    submissions_stuck.each { |s| s.update!(aasm_state: :ingest_failed) }
+    # The following block (Lines 8 to 11), will check for stuck submissions in 'processing' longer than 24hrs.
+    # These submissions are collated into array 'submissions_stuck'. If non-empty, this array is then looped
+    # through to update them as 'failed' (in a database query), to then be resubmitted by a supplier (or not).
+    submissions_stuck = Submission.joins(:task).where("aasm_state = 'processing' and submissions.updated_at < ? and tasks.status != 'completed'", Time.zone.now - 1.day)
+    submissions_stuck.each { |s| s.update!(aasm_state: :ingest_failed) } if submissions_stuck.length.positive?
   end
 
   def show


### PR DESCRIPTION
## Description
RMI-243 Update

## Why was the change made?
Add the conditional so that the database query is only happening if there are stuck submissions present in the first place. Also added comments to the code block I added, to explain for other devs.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 
