### PR TITLE
RMI-10 - invalid dates trigger error message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## [release-111] - 2020-11-24
 
+- Fix: ensure invalid dates trigger error message
+
+## [release-111] - 2020-11-24
+
 - RMI-275: Add to travis.yml and deploy-app.sh to accomodate and add Preproduction to the Travis/Github infrastructure.
 
 ## [release-110] - 2020-11-11

--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -37,7 +37,7 @@ module Ingest
         date_fields.each do |field|
           next if row[field].blank?
 
-          row[field] = Date.parse(row[field]).strftime('%d/%m/%Y') if valid_iso8601_date?(row[field])
+          row[field] = Date.parse(row[field]).strftime('%d/%m/%Y') if valid_date?(row[field])
           row[field] = (Date.new(1899, 12, 30) + row[field].to_i.days).strftime('%d/%m/%Y') if valid_float?(row[field])
         end
 
@@ -77,8 +77,8 @@ module Ingest
         false
       end
 
-      def valid_iso8601_date?(value)
-        !!Date.iso8601(value)
+      def valid_date?(value)
+        !!Date.iso8601(value) && value.match(/\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/)
       rescue ArgumentError
         false
       end


### PR DESCRIPTION
## Description
Added a regex to check dates against.
https://crowncommercialservice.atlassian.net/browse/RMI-10

## Why was the change made?
Dates that were incorrectly formatted or incomplete where passing validation check as they were technically ISO8601 valid, causing the submission to get stuck.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manual testing.
