### PR TITLE
Fix/RMI-12-Out of range number error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,14 @@
 # Change Log
 
+## [release-111] - 2020-12-10
+
+- RMI-12: Fix: If ingested document contains a field with 'E' in (e.g. 705E01510602), it is not converted to number, which causes a stuck submission.
+
 ## [release-111] - 2020-11-26
 
 - Fix: ensure invalid dates trigger error message
-
-## [release-111] - 2020-11-24
-
-- RMI-275: Add to travis.yml and deploy-app.sh to accomodate and add Preproduction to the Travis/Github infrastructure.
-- RMI-243: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method. Also add conditional and comment.
+- RMI-275: Fix: Add to travis.yml and deploy-app.sh to accomodate and add Preproduction to the Travis/Github infrastructure.
+- RMI-243: Feature: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method. Also add conditional and comment.
 
 ## [release-110] - 2020-11-11
 

--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -67,7 +67,7 @@ module Ingest
 
       def convert_numbers(row)
         row.each do |field, value|
-          row[field] = convert_number(value) if valid_float?(value) && !value.match(/E/)
+          row[field] = convert_number(value) if valid_float?(value)
         end
       end
 
@@ -78,7 +78,7 @@ module Ingest
       end
 
       def valid_date?(value)
-        !!Date.iso8601(value) && value.match(/\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/)
+        !!Date.iso8601(value) && value.match(/\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/) && !value.match(/E/)
       rescue ArgumentError
         false
       end

--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -67,14 +67,11 @@ module Ingest
 
       def convert_numbers(row)
         row.each do |field, value|
-          row[field] = convert_number(value) if valid_float?(value)
+          row[field] = convert_number(value) if valid_float?(value) && !value.match(/E/)
         end
       end
 
       def valid_float?(value)
-        # rubocop:disable AllCops
-        return false if value.match?(/E/)
-        # rubocop:enable AllCops
         !!Float(value)
       rescue ArgumentError
         false

--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -72,6 +72,7 @@ module Ingest
       end
 
       def valid_float?(value)
+        return false if value.include? "E"
         !!Float(value)
       rescue ArgumentError
         false

--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -67,7 +67,7 @@ module Ingest
 
       def convert_numbers(row)
         row.each do |field, value|
-          row[field] = convert_number(value) if valid_float?(value)
+          row[field] = convert_number(value) if valid_float?(value) && !value.to_s.match(/E/)
         end
       end
 
@@ -78,7 +78,7 @@ module Ingest
       end
 
       def valid_date?(value)
-        !!Date.iso8601(value) && value.match(/\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/) && !value.match(/E/)
+        !!Date.iso8601(value) && value.match(/\d{4}-(0[1-9]|1[012])-(0[1-9]|[12][0-9]|3[01])/)
       rescue ArgumentError
         false
       end

--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -72,7 +72,9 @@ module Ingest
       end
 
       def valid_float?(value)
-        return false if value.match(/E/)
+        # rubocop:disable AllCops
+        return false if value.match?(/E/)
+        # rubocop:enable AllCops
         !!Float(value)
       rescue ArgumentError
         false

--- a/app/models/ingest/loader/process_csv_row.rb
+++ b/app/models/ingest/loader/process_csv_row.rb
@@ -72,7 +72,7 @@ module Ingest
       end
 
       def valid_float?(value)
-        return false if value.include? "E"
+        return false if value.match(/E/)
         !!Float(value)
       rescue ArgumentError
         false


### PR DESCRIPTION
## Description
RMI-12

## Why was the change made?
If ingested document contains a field with 'E' in (e.g. 705E01510602), it is not converted to number, which causes a stuck submission.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Passed in string '705E01510602', which was the original cause of issue.
