### PR TITLE
RMI-25: Ensure edits to FDL lots blocks are reflected in db

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Change Log
 
-## [release-111] - 2020-12-10
+## [release-112] - 2020-12-10
 
 - RMI-12: Fix: If ingested document contains a field with 'E' in (e.g. 705E01510602), it is not converted to number, which causes a stuck submission.
+- Fix: ensure invalid dates trigger error message.
+- Fix: ensure edits to FDL 'lots' blocks are reflected in db.
 
 ## [release-111] - 2020-11-26
 
-- Fix: ensure invalid dates trigger error message
 - RMI-275: Fix: Add to travis.yml and deploy-app.sh to accomodate and add Preproduction to the Travis/Github infrastructure.
 - RMI-243: Feature: Add auto-fail ingestions stuck in processing after 24hrs feature, inside the users_controller.rb file, index method. Also add conditional and comment.
 
@@ -28,7 +29,7 @@
 
 - Update Travis credentials, from dxw to ccs (password & username).
 
-## [release 107] - 2020-09-22
+## [release-107] - 2020-09-22
 
 - Bump csvkit version from 1.0.4 to 1.0.5
 - Missed excel validations now raise error
@@ -751,7 +752,9 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
-[release-109]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-109...release-110
+[release-112]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-111...release-112
+[release-111]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-110...release-111
+[release-110]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-109...release-110
 [release-109]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-108...release-109
 [release-108]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-107...release-108
 [release-107]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-106...release-107

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -59,6 +59,7 @@ class Framework < ApplicationRecord
         name: generator.definition.framework_name,
         short_name: generator.definition.framework_short_name
       )
+      load_lots!
     else
       # Hand over to the validator
       update(definition_source: definition_source)

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -96,10 +96,12 @@ RSpec.describe Framework do
         FDL
       end
 
-      it { is_expected.to be true }
-
       it 'has updated its name' do
         expect(existing_framework.reload.name).to eql('Changed successfully')
+      end
+
+      it 'loads the lots into the database' do
+        expect(existing_framework.lots.find_by(number: '99', description: 'Fake')).to be_a(FrameworkLot)
       end
     end
 


### PR DESCRIPTION
## Description
https://crowncommercialservice.atlassian.net/browse/RMI-25

## Why was the change made?
Adding suppliers to the new or amended lot numbers was yielding an error, as lots were not updating in the database.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually tested
