### PR TITLE
Revert "Fix/RMI-5-FDL-Additional-Field-Fix"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 ## [release-113] - 2020-12-24
 
 - RMI-25: Updating 'Lots' block in FDL now reflecting in database. Removing lots with active agreements triggers an alert.
-- RMI-5: Fix: 'Additional' (not known) fields should now be transpiled correctly, when used with 'depends_on', and ultimately ingested.
 
 ## [release-112] - 2020-12-10
 

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -39,9 +39,6 @@ class Framework
         rule(type_def: subtree(:type), field: simple(:field), from: subtree(:from)) do
           { kind: :additional, type: type, field: field.to_s, from: from }
         end
-        rule(type_def: subtree(:type), field: simple(:field), from: subtree(:from), depends_on: subtree(:depends_on)) do
-          { kind: :additional, type: type, field: field.to_s, from: from, depends_on: depends_on }
-        end
 
         # Unknown fields rules
         rule(type_def: subtree(:type), from: simple(:from)) do


### PR DESCRIPTION
Since we are deploying a one-off release today, this particular feature needs to be temporarily removed/reverted, as it will not be tested in time.