### PR TITLE
Fix/RMI-5-FDL-Additional-Field-Fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## [release-114] - 2020-12-24
+
+- RMI-5: Fix: 'Additional' (not known) fields should now be transpiled correctly, when used with 'depends_on', and ultimately ingested.
 
 ## [release-113] - 2020-12-16
 

--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -39,6 +39,9 @@ class Framework
         rule(type_def: subtree(:type), field: simple(:field), from: subtree(:from)) do
           { kind: :additional, type: type, field: field.to_s, from: from }
         end
+        rule(type_def: subtree(:type), field: simple(:field), from: subtree(:from), depends_on: subtree(:depends_on)) do
+          { kind: :additional, type: type, field: field.to_s, from: from, depends_on: depends_on }
+        end
 
         # Unknown fields rules
         rule(type_def: subtree(:type), from: simple(:from)) do


### PR DESCRIPTION
## Description
RMI-5

## Why was the change made?
Using the 'Additional' field with 'depends_on' when defining the FDL for a framework would result in that related data not being ingested and committed into the database.

## Are there any dependencies required for this change?
No.

## What type of change is it?

 [X] Bug fix

## How was the change tested?
Submit a FDL for a framework, using 'AdditionalX' as a field with 'depends_on'.
