### PR TITLE
RMI-281

### DIFF
--- a/app/models/task/unfinished_user_notification_list.rb
+++ b/app/models/task/unfinished_user_notification_list.rb
@@ -23,12 +23,8 @@ class Task
 
       output.puts(CSV.generate_line(HEADER))
 
-      suppliers.each do |supplier|
-        supplier.active_users.each do |user|
-          user.submissions.each do |submission|
-            output.puts csv_line_for(user, supplier, submission)
-          end
-        end
+      unfinished_submissions.each do |submission|
+        output.puts csv_line_for(submission.created_by, submission.supplier, submission)
       end
     end
 
@@ -59,10 +55,6 @@ class Task
 
     def in_review?(submission)
       submission.aasm_state.to_s == 'in_review' ? 'y' : 'n'
-    end
-
-    def suppliers
-      Supplier.includes(:active_users, :submissions).joins(:submissions).merge(unfinished_submissions).distinct
     end
 
     def unfinished_submissions

--- a/spec/requests/admin/notify_downloads_spec.rb
+++ b/spec/requests/admin/notify_downloads_spec.rb
@@ -138,8 +138,8 @@ RSpec.describe 'Admin Notify Downloads', type: :request do
         period_year: reporting_period_b.year,
         due_on: due_date_b
       )
-      FactoryBot.create(:submission_with_invalid_entries, supplier: supplier, task: task_a)
-      FactoryBot.create(:submission_with_validated_entries, supplier: supplier, task: task_b)
+      FactoryBot.create(:submission_with_invalid_entries, supplier: supplier, task: task_a, created_by: user)
+      FactoryBot.create(:submission_with_validated_entries, supplier: supplier, task: task_b, created_by: user)
     end
 
     it 'returns an "unfinished" notifications CSV file, with today’s date in the filename' do


### PR DESCRIPTION
## Description
A Notify download for tasks that have submissions that are "in review", "ingest failed" or "validation failed".
https://crowncommercialservice.atlassian.net/browse/RMI-281 

## Why was the change made?
Amended code following QA feedback that rows for tasks that weren't 'unfinished' were being produced.

## Are there any dependencies required for this change?
No.

## What type of change is it?

 [X] New feature 

## How was the change tested?
Unit and manual testing.
