### PR TITLE
amended so that it looks for active users

### DIFF
--- a/app/models/task/unfinished_user_notification_list.rb
+++ b/app/models/task/unfinished_user_notification_list.rb
@@ -60,7 +60,7 @@ class Task
     end
 
     def unfinished_submissions_relation
-      @unfinished_submissions ||= Submission.where(aasm_state: UNFINISHED_STATUSES)
+      @unfinished_submissions_relation ||= Submission.where(aasm_state: UNFINISHED_STATUSES)
     end
 
     def tasks_with_unfinished_submissions

--- a/app/models/task/unfinished_user_notification_list.rb
+++ b/app/models/task/unfinished_user_notification_list.rb
@@ -23,9 +23,9 @@ class Task
 
       output.puts(CSV.generate_line(HEADER))
 
-      unfinished_submissions.each do |submission|
-        submission.supplier.active_users.each do |user|
-          output.puts csv_line_for(user, submission.supplier, submission)
+      tasks_with_unfinished_submissions.each do |task|
+        task.supplier.active_users.each do |user|
+          output.puts csv_line_for(user, task.supplier, task.latest_submission)
         end
       end
     end
@@ -59,8 +59,12 @@ class Task
       submission.aasm_state.to_s == 'in_review' ? 'y' : 'n'
     end
 
-    def unfinished_submissions
+    def unfinished_submissions_relation
       @unfinished_submissions ||= Submission.where(aasm_state: UNFINISHED_STATUSES)
+    end
+
+    def tasks_with_unfinished_submissions
+      Task.incomplete.includes(:submissions).joins(:submissions).merge(unfinished_submissions_relation)
     end
   end
 end

--- a/app/models/task/unfinished_user_notification_list.rb
+++ b/app/models/task/unfinished_user_notification_list.rb
@@ -24,7 +24,9 @@ class Task
       output.puts(CSV.generate_line(HEADER))
 
       unfinished_submissions.each do |submission|
-        output.puts csv_line_for(submission.created_by, submission.supplier, submission)
+        submission.supplier.active_users.each do |user|
+          output.puts csv_line_for(user, submission.supplier, submission)
+        end
       end
     end
 


### PR DESCRIPTION
## Description
An amendment to the code for the new Notify download for 'unfinished' submissions. Now ensures it looks for active users.
https://crowncommercialservice.atlassian.net/browse/RMI-281

## Why was the change made?
Testing feedback.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

 [X] New feature 

## How was the change tested?
Manually tested in local.
