### PR TITLE
Feature/rmi 281

### DIFF
--- a/app/models/task/unfinished_user_notification_list.rb
+++ b/app/models/task/unfinished_user_notification_list.rb
@@ -7,7 +7,7 @@ class Task
   # objects that respond_to? it (+STDOUT+ or +File+ being usual)
   class UnfinishedUserNotificationList
     UNFINISHED_STATUSES = ['validation_failed', 'ingest_failed', 'in_review'].freeze
-    HEADER = ['email address', 'person_name', 'supplier_name', 'task_name'] + UNFINISHED_STATUSES.freeze
+    HEADER = ['email address', 'task_period', 'person_name', 'supplier_name', 'task_name', 'submission_date'] + UNFINISHED_STATUSES.freeze
 
     attr_reader :logger, :output
 
@@ -25,16 +25,16 @@ class Task
 
       tasks_with_unfinished_submissions.each do |task|
         task.supplier.active_users.each do |user|
-          output.puts csv_line_for(user, task.supplier, task.latest_submission)
+          output.puts csv_line_for(user, task.supplier, task.latest_submission, task)
         end
       end
     end
 
     private
 
-    def csv_line_for(user, supplier, submission)
+    def csv_line_for(user, supplier, submission, task)
       CSV.generate_line(
-        [user.email, user.name, supplier.name, task_name(submission), validation_failed?(submission), ingest_failed?(submission), in_review?(submission)]
+        [user.email, task_month_and_year(task), user.name, supplier.name, task_name(task), submission_date(submission), validation_failed?(submission), ingest_failed?(submission), in_review?(submission)]
       )
     end
 
@@ -42,9 +42,12 @@ class Task
       "#{Date::MONTHNAMES[task.period_month]} #{task.period_year}"
     end
 
-    def task_name(submission)
-      task = submission.task
+    def task_name(task)
       "#{task.framework.short_name} - #{task.framework.name} - #{task_month_and_year(task)}"
+    end
+
+    def submission_date(submission)
+      submission.updated_at.strftime('%d/%m/%Y')
     end
 
     def validation_failed?(submission)

--- a/spec/requests/admin/notify_downloads_spec.rb
+++ b/spec/requests/admin/notify_downloads_spec.rb
@@ -150,11 +150,11 @@ RSpec.describe 'Admin Notify Downloads', type: :request do
       expect(response.header['Content-Disposition'])
         .to eq 'attachment; filename="unfinished_notifications-2019-04-09.csv"'
       expect(response.body)
-        .to include 'email address,person_name,supplier_name,task_name'
+        .to include 'email address,task_period,person_name,supplier_name,task_name'
       expect(response.body)
         .to include 'validation_failed,ingest_failed,in_review'
-      expect(response.body).to include 'February 2019,y,n,n'
-      expect(response.body).to include 'March 2019,n,n,y'
+      expect(response.body).to include 'February 2019,09/04/2019,y,n,n'
+      expect(response.body).to include 'March 2019,09/04/2019,n,n,y'
     end
   end
 


### PR DESCRIPTION
## Description
An amendment to the code for the new Notify download for 'unfinished' submissions. Now has two additional columns and a slightly different order
https://crowncommercialservice.atlassian.net/browse/RMI-281?focusedCommentId=28951

## Why was the change made?
Admin team testing feedback.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually tested in local.
