### PR TITLE
Feature/rmi 31 template access

### DIFF
--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -12,6 +12,8 @@
           = link_to 'Download users (CSV)', users_admin_framework_reports_path(@framework)
         %li.govuk-page-actions--action
           = link_to 'Download suppliers/lots (CSV)', lots_admin_framework_reports_path(@framework)
+        %li.govuk-page-actions--action
+          = link_to 'Download template (excel document)', rails_blob_path(@framework.template_file, disposition: "attachment"), {'aria-label' => "Download excel document template for #{@framework.short_name} #{@framework.name}"}
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -13,7 +13,8 @@
         %li.govuk-page-actions--action
           = link_to 'Download suppliers/lots (CSV)', lots_admin_framework_reports_path(@framework)
         %li.govuk-page-actions--action
-          = link_to 'Download template (excel document)', rails_blob_path(@framework.template_file, disposition: "attachment"), {'aria-label' => "Download excel document template for #{@framework.short_name} #{@framework.name}"}
+          - if @framework.template_file.attached?
+            = link_to 'Download template (excel document)', rails_blob_path(@framework.template_file, disposition: "attachment"), {'aria-label' => "Download excel document template for #{@framework.short_name} #{@framework.name}"}
 
 .govuk-grid-row
   .govuk-grid-column-full


### PR DESCRIPTION
## Description
Making blank templates available to admin to download on framework page.
https://crowncommercialservice.atlassian.net/browse/RMI-31

## Why was the change made?
Feature requested by admin staff- quality of life improvement.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually
