### PR TITLE
Feature/rmi 282

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -121,6 +121,7 @@ Lint/UnderscorePrefixedVariableName:
 Metrics/CyclomaticComplexity:
     Exclude:
         - 'app/models/framework/definition/ast/field.rb'
+        - 'app/models/framework/definition/ast/semantic_checker.rb'
 
 Metrics/PerceivedComplexity:
     Exclude:

--- a/app/models/export/invoices.rb
+++ b/app/models/export/invoices.rb
@@ -6,7 +6,7 @@ module Export
       SubmissionID
       CustomerURN
       CustomerName
-      CustomerPostcode
+      CustomerPostCode
       InvoiceDate
       InvoiceNumber
       SupplierReferenceNumber

--- a/app/models/framework/definition/RM3787.fdl
+++ b/app/models/framework/definition/RM3787.fdl
@@ -38,7 +38,7 @@ Framework RM3787 {
     SupplierReferenceNumber from 'Supplier Reference Number'
     CustomerURN from 'Customer URN'
     CustomerName from 'Customer Organisation Name'
-    CustomerPostcode from 'Customer Post Code'
+    CustomerPostCode from 'Customer Post Code'
     CustomerReferenceNumber from 'Matter Name'
     String Additional7 from 'Matter Description'
     ContractStartDate from 'Contract Start Date'

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -125,7 +125,7 @@ class Framework
           if field.nil?
             raise Transpiler::Error, "Management charge references '#{referenced_field_name}' which does not exist"
           end
-          
+
           raise Transpiler::Error, "Management charge references '#{referenced_field_name}' so it cannot be optional" if field.optional?
         end
       end

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -125,9 +125,8 @@ class Framework
           if field.nil?
             raise Transpiler::Error, "Management charge references '#{referenced_field_name}' which does not exist"
           end
-          if field.optional?
-            raise Transpiler::Error, "Management charge references '#{referenced_field_name}' so it cannot be optional"
-          end
+          
+          raise Transpiler::Error, "Management charge references '#{referenced_field_name}' so it cannot be optional" if field.optional?
         end
       end
     end

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -52,14 +52,14 @@ class Framework
         def export_headers_for(entry_type)
           case entry_type
           when :invoice
-            return Export::Invoices::HEADER
+            Export::Invoices::HEADER
           when :contract
-            return Export::Contracts::HEADER
+            Export::Contracts::HEADER
           else
-            return Export::Others::HEADER
+            Export::Others::HEADER
           end
         end
-        
+
         def raise_mapping_error(field, entry_type)
           raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the #{entry_type.capitalize}Fields block"
         end

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -48,30 +48,16 @@ class Framework
 
           case entry_type
           when :invoice
-            validate_invoice_fields_block(field)
+            raise_mapping_error(field, entry_type) unless Export::Invoices::HEADER.include? field.warehouse_name
           when :contract
-            validate_contract_fields_block(field)
+            raise_mapping_error(field, entry_type) unless Export::Contracts::HEADER.include? field.warehouse_name
           else
-            validate_other_fields_block(field)
+            raise_mapping_error(field, entry_type) unless Export::Others::HEADER.include? field.warehouse_name
           end
         end
 
-        def validate_invoice_fields_block(field)
-          unless Export::Invoices::HEADER.include? field.warehouse_name
-            raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the InvoiceFields block"
-          end
-        end
-
-        def validate_contract_fields_block(field)
-          unless Export::Contracts::HEADER.include? field.warehouse_name
-            raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the ContractFields block"
-          end
-        end
-
-        def validate_other_fields_block(field)
-          unless Export::Others::HEADER.include? field.warehouse_name
-            raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the OtherFields block"
-          end
+        def raise_mapping_error(field, entry_type)
+          raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the #{entry_type.capitalize}Fields block"
         end
 
         def raise_when_dependent_reference_invalid(field, entry_type)

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -42,7 +42,7 @@ class Framework
         end
 
         def validate_field_mapping(field, entry_type)
-          excluded_headers = %w[CustomerPostcode CustomerPostCode UnitCost VATIncluded UNSPSC CustomerInvoiceDate CustOrderDate]
+          excluded_headers = %w[CustomerPostCode UnitCost VATIncluded UNSPSC CustomerInvoiceDate CustOrderDate]
 
           return if excluded_headers.include?(field.warehouse_name) || field.unknown?
 

--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -48,17 +48,29 @@ class Framework
 
           case entry_type
           when :invoice
-            unless Export::Invoices::HEADER.include? field.warehouse_name
-              raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the InvoiceFields block"
-            end
+            validate_invoice_fields_block(field)
           when :contract
-            unless Export::Contracts::HEADER.include? field.warehouse_name
-              raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the ContractFields block"
-            end
+            validate_contract_fields_block(field)
           else
-            unless Export::Others::HEADER.include? field.warehouse_name
-              raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the OtherFields block"
-            end
+            validate_other_fields_block(field)
+          end
+        end
+
+        def validate_invoice_fields_block(field)
+          unless Export::Invoices::HEADER.include? field.warehouse_name
+            raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the InvoiceFields block"
+          end
+        end
+
+        def validate_contract_fields_block(field)
+          unless Export::Contracts::HEADER.include? field.warehouse_name
+            raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the ContractFields block"
+          end
+        end
+
+        def validate_other_fields_block(field)
+          unless Export::Others::HEADER.include? field.warehouse_name
+            raise Transpiler::Error, "#{field.warehouse_name} is not an exported field in the OtherFields block"
           end
         end
 

--- a/app/models/framework/definition/data_warehouse/known_fields.rb
+++ b/app/models/framework/definition/data_warehouse/known_fields.rb
@@ -8,7 +8,6 @@ class Framework
           'InvoiceValue' => :decimal,
           'ContractValue' => :decimal,
           'CustomerPostCode' => :string,
-          'CustomerPostcode' => :string,
           'CustomerName' => :string,
           'CustomerURN' => :urn,
           'InvoiceDate' => :date,

--- a/docs/data-warehouse-export.md
+++ b/docs/data-warehouse-export.md
@@ -54,7 +54,7 @@ information. The export contains the following fields.
   - SubmissionID:             unique identifier for the submission for the invoice
   - CustomerURN:              customer URN for the invoice
   - CustomerName:             name for the invoice customer
-  - CustomerPostcode:         postcode for the invoice customer
+  - CustomerPostCode:         postcode for the invoice customer
   - InvoiceDate:              invoice date for the invoice
   - InvoiceNumber:            invoice number for the invoice
   - SupplierReferenceNumber:  reference number from the supplier
@@ -84,7 +84,7 @@ defined in the framework definitions.
   - SubmissionID              unique identifier for the submission for the contract
   - CustomerURN:              customer URN for the invoice
   - CustomerName:             name for the invoice customer
-  - CustomerPostcode:         postcode for the invoice customer
+  - CustomerPostCode:         postcode for the invoice customer
   - SupplierReferenceNumber:  reference number from the supplier
   - CustomerReferenceNumber:  reference number from the customer
   - LotNumber:                lot number for the invoice

--- a/spec/fixtures/rm1043iv.fdl
+++ b/spec/fixtures/rm1043iv.fdl
@@ -62,7 +62,6 @@ Framework RM1043iv {
     }
     String Additional6 from 'Location'
     Decimal Additional7 from 'Day Rate'
-    UnitQuantity from 'Quantity'
     ContractValue from 'Total Value'
   }
 

--- a/spec/fixtures/rm3787.fdl
+++ b/spec/fixtures/rm3787.fdl
@@ -38,7 +38,7 @@ Framework RM3787 {
     SupplierReferenceNumber from 'Supplier Reference Number'
     CustomerURN from 'Customer URN'
     CustomerName from 'Customer Organisation Name'
-    CustomerPostcode from 'Customer Post Code'
+    CustomerPostCode from 'Customer Post Code'
     CustomerReferenceNumber from 'Matter Name'
     String Additional7 from 'Matter Description'
     ContractStartDate from 'Contract Start Date'

--- a/spec/models/export/relation_spec.rb
+++ b/spec/models/export/relation_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe Export::Relation do
 
     it 'writes a header for the invoices export' do
       expect(output_lines.first).to eql(
-        'SubmissionID,CustomerURN,CustomerName,CustomerPostcode,InvoiceDate,InvoiceNumber,'\
+        'SubmissionID,CustomerURN,CustomerName,CustomerPostCode,InvoiceDate,InvoiceNumber,'\
         'SupplierReferenceNumber,CustomerReferenceNumber,LotNumber,ProductDescription,'\
         'ProductGroup,ProductClass,ProductSubClass,ProductCode,UnitType,UnitPrice,UnitQuantity,'\
         'InvoiceValue,Expenses,VATCharged,PromotionCode,ManagementChargeValue,'\

--- a/spec/models/framework/definition/generator_spec.rb
+++ b/spec/models/framework/definition/generator_spec.rb
@@ -691,6 +691,29 @@ RSpec.describe Framework::Definition::Generator do
       end
     end
 
+    context "field mapping will not be exported" do
+      let(:source) do
+        <<~FDL
+          Framework RM6060 {
+            Name 'Fake framework'
+            ManagementCharge 0.5% of 'Supplier Price'
+            Lots { '99' -> 'Fake' }
+
+            InvoiceFields {
+              InvoiceValue from 'Supplier Price'
+              ContractStartDate from 'Contract Start Date'
+            }
+          }
+        FDL
+      end
+
+      it 'has the error' do
+        expect(generator.error).to eql(
+          "ContractStartDate is not an exported field in the InvoiceFields block"
+        )
+      end
+    end
+    
     context 'mismatched depends_on fields and values' do
       let(:source) do
         <<~FDL

--- a/spec/models/framework/definition/generator_spec.rb
+++ b/spec/models/framework/definition/generator_spec.rb
@@ -691,7 +691,7 @@ RSpec.describe Framework::Definition::Generator do
       end
     end
 
-    context "field mapping will not be exported" do
+    context 'field mapping will not be exported' do
       let(:source) do
         <<~FDL
           Framework RM6060 {
@@ -709,7 +709,7 @@ RSpec.describe Framework::Definition::Generator do
 
       it 'has the error' do
         expect(generator.error).to eql(
-          "ContractStartDate is not an exported field in the InvoiceFields block"
+          'ContractStartDate is not an exported field in the InvoiceFields block'
         )
       end
     end

--- a/spec/models/framework/definition/generator_spec.rb
+++ b/spec/models/framework/definition/generator_spec.rb
@@ -713,7 +713,7 @@ RSpec.describe Framework::Definition::Generator do
         )
       end
     end
-    
+
     context 'mismatched depends_on fields and values' do
       let(:source) do
         <<~FDL


### PR DESCRIPTION
## Description
https://crowncommercialservice.atlassian.net/browse/RMI-282

## Why was the change made?
Semantic checker should reject field mappings in FDL that will not be exported

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manual and unit testing.
