### PR TITLE
RMI-45

### DIFF
--- a/app/models/framework/definition/ast/semantic_checker.rb
+++ b/app/models/framework/definition/ast/semantic_checker.rb
@@ -102,6 +102,7 @@ class Framework
         end
 
         def raise_when_management_field_invalid(info)
+          validate_multi_column_management_charge(info) if info[:column_based]
           of_columns_for(info).each { |referenced_field_name| validate_management_field(referenced_field_name) }
         end
 
@@ -129,6 +130,15 @@ class Framework
           end
 
           raise Transpiler::Error, "Management charge references '#{referenced_field_name}' so it cannot be optional" if field.optional?
+        end
+
+        def validate_multi_column_management_charge(info)
+          management_field_keys = info[:column_based][:value_to_percentage].keys
+          management_field_keys.each do |key_array|
+            if key_array[0] == '<Any>'
+              raise Transpiler::Error, "The first criterion in a multiple depends-on validation cannot be a wildcard."
+            end
+          end
         end
       end
     end

--- a/spec/models/framework/definition/generator_spec.rb
+++ b/spec/models/framework/definition/generator_spec.rb
@@ -517,6 +517,17 @@ RSpec.describe Framework::Definition::Generator do
           )
         end
       end
+
+      context 'a field begins with a wildcard' do
+        let(:invalid_source) { valid_source.sub('\'1\', \'Damage\' -> 0%', '*, \'Damage\' -> 0%') }
+        let(:source)         { invalid_source }
+
+        it 'has an error' do
+          expect(generator.error).to eql(
+            "The first criterion in a multiple depends-on validation cannot be a wildcard."
+          ) 
+        end
+      end
     end
 
     context 'Composing lookups from other lookups - RM3787' do


### PR DESCRIPTION
## Description
Added transpiler error for when a field in a multi-column management charge block begins with a wildcard.
https://crowncommercialservice.atlassian.net/browse/RMI-45

## Why was the change made?
Such FDL was not being rejected, then management charge calculations would later fail to work correctly.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Unit and manual testing.
