### PR TITLE
RMI-27-Remove-Beta-Banner

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [release-118] - 2021-03-18
+
+- RMI-27: Removed beta banner
+
 ## [release-117] - 2021-03-04
 
 - RMI-282: Added field mapping validator to prevent fields failing to export.

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -19,6 +19,8 @@
 
     = render 'shared/header', no_navigation: false
 
+    .govuk-width-container
+
 
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 

--- a/app/views/layouts/admin.html.haml
+++ b/app/views/layouts/admin.html.haml
@@ -19,16 +19,6 @@
 
     = render 'shared/header', no_navigation: false
 
-    .govuk-width-container
-      .govuk-phase-banner
-        %p.govuk-phase-banner__content
-          %strong.govuk-tag.govuk-phase-banner__content__tag
-            beta
-          %span.govuk-phase-banner__text
-            This is a new service – your
-            = mail_to support_email_address, 'feedback', class: 'govuk-link'
-            will help us to improve it.
-
 
       %main{ role: 'main', id: 'main-content', class: 'govuk-main-wrapper'}
 


### PR DESCRIPTION
## Description
RMI-27

## Why was the change made?
No longer in beta.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Locally and visually.
