### PR TITLE
RMI-319-Move-Missing-Task-Link-And-Update-Mime-Magic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [release-119] - 2021-04-01
 
 - RMI-319: Moved 'Add Tasks' button.
+- Update mime0magic dependancy gem.
 
 ## [release-118] - 2021-03-18
 

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -8,6 +8,7 @@
       %ul.govuk-page-actions--actions
         %li.govuk-page-actions--action
           = link_to 'Edit supplier', edit_admin_supplier_path(@supplier)
+        %li.govuk-page-actions--action
           = link_to "Add a missing task", new_admin_supplier_task_path(@supplier)
 
 .govuk-grid-row


### PR DESCRIPTION
## Description
RMI-319.
Updated mimemagic gem.

## Why was the change made?
User Feedback.
Version was yanked by devs.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Browser test and ran app, also pipeline tested.
