### PR TITLE
Update-Ruby-From-2.5.7-To-2.5.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.5.7
+- 2.5.8
 services:
   - postgresql
 addons:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [release-120] - 2021-05-13
 
 - RMI-345: set up conclave branch to deploy rmi-conclave integration work to preprod env
+- RMI-343: Update Ruby version from 2.5.7 to 2.5.8 (minor update).
 
 ## [release-119] - 2021-04-01
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.7'
+ruby '2.5.8'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,7 +500,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.5.7p206
+   ruby 2.5.8p224
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## Description
RMI-343

## Why was the change made?
GDS ruby buildpacks support is ending for 2.5.7 ruby versions.

## Are there any dependencies required for this change?
No.

## What type of change is it?

 [X] New feature 

 [X] Breaking change

## How was the change tested?
Smoke test/ran the app and tested.
