### PR TITLE
Merge dev into conclave to update ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-- 2.5.7
+- 2.5.8
 services:
   - postgresql
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -53,7 +53,7 @@ deploy:
   - provider: script
     script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s preprod
     on:
-      branch: preproduction
+      branch: conclave
   - provider: script
     script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s prod
     on:

--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -93,9 +93,9 @@ then
 
   if [[ "$CF_SPACE" == "preprod" ]]
   then
-    if [[ ! "$BRANCH" == "preproduction" ]]
+    if [[ ! "$BRANCH" == "conclave" ]]
     then
-      echo "We only deploy the 'preproduction' branch to $CF_SPACE"
+      echo "We only deploy the 'conclave' branch to $CF_SPACE"
       echo "if you want to deploy $BRANCH to $CF_SPACE use -f"
       exit 1
     fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## [release-120] - 2021-05-13
 
 - RMI-345: set up conclave branch to deploy rmi-conclave integration work to preprod env
+- RMI-343: Update Ruby version from 2.5.7 to 2.5.8 (minor update).
 
 ## [release-119] - 2021-04-01
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [release-120] - 2021-05-13
+
+- RMI-345: set up conclave branch to deploy rmi-conclave integration work to preprod env
+
 ## [release-119] - 2021-04-01
 
 - RMI-319: Moved 'Add Tasks' button.
@@ -786,6 +790,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-120]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-119...release-120
 [release-119]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-118...release-119
 [release-118]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-117...release-118
 [release-117]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-116...release-117

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '2.5.7'
+ruby '2.5.8'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '~> 5.2.4.5'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -500,7 +500,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.5.7p206
+   ruby 2.5.8p224
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
## Description
RMI-343

## Why was the change made?
GDS ruby buildpacks support is ending for 2.5.7 ruby versions.

## Are there any dependencies required for this change?
No.

## What type of change is it?

 [X] New feature 

 [X] Breaking change

## How was the change tested?
Smoke test/ran the app and tested.
