### PR TITLE
RMI-36-Filter-DB-Dependancy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 # Change Log
 
-## [release-120] - 2021-05-13
+## [release-120] - 2021-05-27
 
 - RMI-345: set up conclave branch to deploy rmi-conclave integration work to preprod env
 - RMI-343: Update Ruby version from 2.5.7 to 2.5.8 (minor update).
+- RMI-36: Backend dependancy for front-end filtering (adds a paramter dig to the tasks controller)
 
 ## [release-119] - 2021-04-01
 

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -5,7 +5,8 @@ class V1::TasksController < APIController
     tasks = current_user.tasks
     tasks = tasks.includes(:supplier).includes(requested_associations)
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
-
+    tasks = tasks.where(framework_id: params.dig(:filter, :framework_id)) if params.dig(:filter, :framework_id)
+    
     render jsonapi: tasks, include: params[:include], fields: sparse_field_params
   end
 

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -6,7 +6,7 @@ class V1::TasksController < APIController
     tasks = tasks.includes(:supplier).includes(requested_associations)
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
     tasks = tasks.where(framework_id: params.dig(:filter, :framework_id)) if params.dig(:filter, :framework_id)
-    
+
     render jsonapi: tasks, include: params[:include], fields: sparse_field_params
   end
 


### PR DESCRIPTION
## Description
RMI-36

## Why was the change made?
Dependency needed to query DB, for the front end filter.

## Are there any dependencies required for this change?
Yes, front-end

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Tested by running query and seeing results.
