### PR TITLE
Conclave-Deployment-Fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ deploy:
     on:
       branch: develop
   - provider: script
-    script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s preprod
+    script: bash CF/deploy-app.sh -u $CF_USER -o $CF_ORG -p $CF_PASS -s conclave-development
     on:
       branch: conclave
   - provider: script


### PR DESCRIPTION
This is a fix for the 'preprod' environment in CF being renamed to 'conclave-development'.
All apps and services are still ending with "-preprod" in conclave-development env, so this is a fix for the pipeline, to continue deploying as normal. Compatible with all of our envs/branches now.