### PR TITLE
Conclave-Deployment-Fix

### DIFF
--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -144,7 +144,7 @@ cf target -o "$CF_ORG" -s "$CF_SPACE"
 # It's easier to manually adjust this here, after the env has been selected already as conclave-development, so set it back.
 if [[ "$CF_SPACE" == "conclave-development" ]]
 then
-  "$CF_SPACE" = "preprod"
+  CF_SPACE = "preprod"
 fi
 
 # generate manifest


### PR DESCRIPTION
This is a fix for the 'preprod' environment in CF being renamed to 'conclave-development'.
All apps and services are still ending with "-preprod" in conclave-development env, so this is a fix for the pipeline, to continue deploying as normal. Compatible with all of our envs/branches now.