### PR TITLE
update-ruby-buildpack-to-supported-version

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -2,6 +2,8 @@
 applications:
   - name: ccs-rmi-api-CF_SPACE
     memory: MEMORY_LIMIT
+    buildpacks:
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.42
     instances: INSTANCE_COUNT
     routes:
       - route: ccs-rmi-api-CF_SPACE.apps.internal

--- a/CF/sidekiq-manifest-template.yml
+++ b/CF/sidekiq-manifest-template.yml
@@ -2,6 +2,8 @@
 applications:
   - name: ccs-rmi-api-sidekiq-SIDEKIQ_QUEUE_NAME-CF_SPACE
     memory: SIDEKIQ_MEMORY_LIMIT
+    buildpacks:
+    - https://github.com/cloudfoundry/ruby-buildpack.git#v1.8.42
     disk_quota: SIDEKIQ_DISK_QUOTA
     instances: SIDEKIQ_INSTANCE_COUNT
     services:


### PR DESCRIPTION
## Description
Updated to buildpack that supports ruby version

## Why was the change made?
Support was changing.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix