### PR TITLE
increase-api-memory-limit

### DIFF
--- a/CF/deploy-app.sh
+++ b/CF/deploy-app.sh
@@ -22,7 +22,7 @@ then
  usage
 fi
 
-MEMORY_LIMIT="512M"
+MEMORY_LIMIT="1G"
 INSTANCE_COUNT="1"
 
 SIDEKIQ_DEFAULT_INSTANCE_COUNT="1"
@@ -120,7 +120,7 @@ if [[ "$CF_SPACE" == "staging" || "$CF_SPACE" == "preprod" || "$CF_SPACE" == "pr
   echo "      name other than staging / preprod / prod"
   echo " *********************************************"
 
-  MEMORY_LIMIT="512M"
+  MEMORY_LIMIT="1G"
   INSTANCE_COUNT="3"
 
   SIDEKIQ_DEFAULT_MEMORY_LIMIT="2048M"


### PR DESCRIPTION
## Description
Memory increase for the hosted API App.

## Why was the change made?
API Admin App (exclusively) was crashing, with 'out of memory' issues, when a particular task was being ran.

## Are there any dependencies required for this change?
IS NOT REQUIRED for Front-End. API only, to save.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

 [X] New feature 

## How was the change tested?
Ran manual command to increase memory in staging first, then the same in production after. App ran fine, with no further memory issues.
