### PR TITLE
RMI-500

### DIFF
--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -1,5 +1,5 @@
 class DataWarehouseExport < ApplicationRecord
-  EARLIEST_RANGE_FROM = Time.new(2022, 2, 8).utc
+  EARLIEST_RANGE_FROM = Time.new(2000, 1, 1).utc
 
   after_initialize :set_date_range
 

--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -1,5 +1,5 @@
 class DataWarehouseExport < ApplicationRecord
-  EARLIEST_RANGE_FROM = Time.new(2000, 1, 1).utc.freeze
+  EARLIEST_RANGE_FROM = Time.new(2000, 1, 1).utc
 
   after_initialize :set_date_range
 

--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -1,5 +1,5 @@
 class DataWarehouseExport < ApplicationRecord
-  EARLIEST_RANGE_FROM = Time.new(2000, 1, 1).utc
+  EARLIEST_RANGE_FROM = Time.new(2022, 2, 8).utc
 
   after_initialize :set_date_range
 


### PR DESCRIPTION
## Description
Removed freeze method from DWExport start date constant to allow flexibility when reexporting.
https://crowncommercialservice.atlassian.net/browse/RMI-500

## Why was the change made?
An incomplete export needs to be redone

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
N/A
