### PR TITLE
Update-lolsoap-dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,7 +69,7 @@ gem 'parslet'
 gem 'rubyXL', '~> 3.4', '>= 3.4.18'
 
 # SOAP-related libraries for Workday integration
-gem 'lolsoap', '>= 0.9.0', require: false
+gem 'lolsoap', '>= 0.10.0', require: false
 gem 'akami', '>= 1.3.1', require: false
 gem 'http', '>= 4.0.0'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,7 +511,7 @@ DEPENDENCIES
   launchy (>= 2.4.3)
   listen (>= 3.0.5, < 3.2)
   lograge (>= 0.11.2)
-  lolsoap (>= 0.9.0)
+  lolsoap (>= 0.10.0)
   omniauth-google-oauth2
   omniauth-rails_csrf_protection (~> 1.0, >= 1.0.0)
   parslet


### PR DESCRIPTION
Issue raised by Snyk PR - applies update to 'lolsoap' dependency.

Version Bump: 0.9.0 -> 0.10.0.