### PR TITLE
disable-daily-export-temporarily

### DIFF
--- a/config/sidekiq_schedule.yml
+++ b/config/sidekiq_schedule.yml
@@ -2,7 +2,7 @@ monthly_tasks_generation:
   cron: '0 2 1 * *'
   class: 'MonthlyTasksGenerationJob'
   queue: default
-daily_data_warehouse_export:
-  cron: '30 20 * * * Europe/London'
-  class: DataWarehouseExportJob
-  queue: default
+# daily_data_warehouse_export:
+  # cron: '30 20 * * * Europe/London'
+  # class: DataWarehouseExportJob
+  # queue: default


### PR DESCRIPTION
Temporarily disable the daily export job, ran by sidekiq, in order to give the current one enough time to complete.