### PR TITLE
RMI-501-Staging-Table-V2

### DIFF
--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -11,6 +11,7 @@ class DataWarehouseExport < ApplicationRecord
         export.save!
       end
     end
+    SubmissionEntriesStage.delete_all
   end
 
   def generate_files

--- a/app/models/export/contracts/extract.rb
+++ b/app/models/export/contracts/extract.rb
@@ -6,7 +6,7 @@ module Export
         submission_scope = submission_scope.where(updated_at: date_range) if date_range.present?
 
         SubmissionEntry.orders
-                       .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
+                       .select('submission_entries_stages.*, frameworks.short_name AS _framework_short_name')
                        .joins(submission: :framework)
                        .merge(submission_scope)
       end

--- a/app/models/export/invoices/extract.rb
+++ b/app/models/export/invoices/extract.rb
@@ -6,7 +6,7 @@ module Export
         submission_scope = submission_scope.where(updated_at: date_range) if date_range.present?
 
         SubmissionEntry.invoices
-                       .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
+                       .select('submission_entries_stages.*, frameworks.short_name AS _framework_short_name')
                        .joins(submission: :framework)
                        .merge(submission_scope)
       end

--- a/app/models/export/others/extract.rb
+++ b/app/models/export/others/extract.rb
@@ -6,7 +6,7 @@ module Export
         submission_scope = submission_scope.where(updated_at: date_range) if date_range.present?
 
         SubmissionEntry.others
-                       .select('submission_entries.*, frameworks.short_name AS _framework_short_name')
+                       .select('submission_entries_stages.*, frameworks.short_name AS _framework_short_name')
                        .joins(submission: :framework)
                        .merge(submission_scope)
       end


### PR DESCRIPTION
## Description
RMI-501

## Why was the change made?
Date Export taking a long time to complete, for a given a table, as it was too large.

## Are there any dependencies required for this change?
Database table `submission_entries_stages` exists in the environment.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Over two weeks, with various submissions by different people.
