### PR TITLE
Remove tax_code_id related code and specs

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,5 +5,7 @@ plugins:
     channel: rubocop-1-10-0
 exclude_patterns:
 - "app/models/framework/definition/ast/semantic_checker.rb"
+- "app/models/workday/submit_invoice.rb"
+- "app/models/workday/submit_invoice_adjustment.rb"
 - "spec/"
 - "db/"

--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -7,5 +7,7 @@ exclude_patterns:
 - "app/models/framework/definition/ast/semantic_checker.rb"
 - "app/models/workday/submit_invoice.rb"
 - "app/models/workday/submit_invoice_adjustment.rb"
+- "app/models/workday/submit_reversal_invoice.rb"
+- "app/models/workday/submit_reversal_invoice_adjustment.rb"
 - "spec/"
 - "db/"

--- a/app/models/workday/commercial_agreements.rb
+++ b/app/models/workday/commercial_agreements.rb
@@ -12,15 +12,15 @@ module Workday
       result
     end
 
-    def tax_code_ids
-      result = {}
-      report_entries.each do |report_entry|
-        framework_number = report_entry.at_xpath('wd:Framework_Number').text
-        tax_code_xml = report_entry.at_xpath('wd:Tax_Code_Reference/wd:ID[@wd:type="commercialAgreementTaxCode"]')
-        result[framework_number] = tax_code_xml.text if tax_code_xml
-      end
-      result
-    end
+    # def tax_code_ids
+    #   result = {}
+    #   report_entries.each do |report_entry|
+    #     framework_number = report_entry.at_xpath('wd:Framework_Number').text
+    #     tax_code_xml = report_entry.at_xpath('wd:Tax_Code_Reference/wd:ID[@wd:type="commercialAgreementTaxCode"]')
+    #     result[framework_number] = tax_code_xml.text if tax_code_xml
+    #   end
+    #   result
+    # end
 
     private
 

--- a/app/models/workday/submit_invoice.rb
+++ b/app/models/workday/submit_invoice.rb
@@ -42,7 +42,7 @@ module Workday
             invoice_line.Extended_Amount            formatted_management_charge
             invoice_line.Analytical_Amount          formatted_total_spend
             invoice_line.Worktags_Reference.ID      framework.short_name, 'ns0:type': 'Custom_Organization_Reference_ID'
-            invoice_line.Tax_Code_Reference.ID      tax_code_id, 'ns0:type': 'Tax_Code_ID'
+            # invoice_line.Tax_Code_Reference.ID      tax_code_id, 'ns0:type': 'Tax_Code_ID'
             invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'Revenue_Category_ID'
           end
         end
@@ -62,9 +62,9 @@ module Workday
       workday_commercial_agreements.revenue_category_ids[framework.short_name]
     end
 
-    def tax_code_id
-      workday_commercial_agreements.tax_code_ids[framework.short_name]
-    end
+    # def tax_code_id
+    #   workday_commercial_agreements.tax_code_ids[framework.short_name]
+    # end
 
     def invoice_memo
       "Submission ID: #{submission.id}"

--- a/app/models/workday/submit_invoice_adjustment.rb
+++ b/app/models/workday/submit_invoice_adjustment.rb
@@ -48,7 +48,7 @@ module Workday
             invoice_line.Extended_Amount            formatted_management_charge
             invoice_line.Analytical_Amount          formatted_total_spend
             invoice_line.Worktags_Reference.ID      framework.short_name, 'ns0:type': 'Custom_Organization_Reference_ID'
-            invoice_line.Tax_Code_Reference.ID      tax_code_id, 'ns0:type': 'Tax_Code_ID'
+            # invoice_line.Tax_Code_Reference.ID      tax_code_id, 'ns0:type': 'Tax_Code_ID'
             invoice_line.Revenue_Category_Reference.ID framework_revenue_category_id, 'ns0:type': 'Revenue_Category_ID'
           end
         end
@@ -68,9 +68,9 @@ module Workday
       workday_commercial_agreements.revenue_category_ids[framework.short_name]
     end
 
-    def tax_code_id
-      workday_commercial_agreements.tax_code_ids[framework.short_name]
-    end
+    # def tax_code_id
+    #   workday_commercial_agreements.tax_code_ids[framework.short_name]
+    # end
 
     def invoice_memo
       "Submission ID: #{submission.id}"

--- a/spec/models/workday/commercial_agreements_spec.rb
+++ b/spec/models/workday/commercial_agreements_spec.rb
@@ -18,21 +18,21 @@ RSpec.describe Workday::CommercialAgreements do
     end
   end
 
-  describe '#tax_code_ids' do
-    it 'should return Tax Code IDs' do
-      expect(subject.tax_code_ids).to eq(
-        'A206100' => 'GBC20'
-      )
-    end
+  # describe '#tax_code_ids' do
+  #   it 'should return Tax Code IDs' do
+  #     expect(subject.tax_code_ids).to eq(
+  #       'A206100' => 'GBC20'
+  #     )
+  #   end
 
-    context 'when the workday API returns a 500 status code' do
-      it 'raises an error' do
-        stub_request(:get, 'https://wd3-impl-services1.workday.com/ccx/service/customreport2/tenant/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category')
-          .with(headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' })
-          .to_return(status: 500, body: '')
+  #   context 'when the workday API returns a 500 status code' do
+  #     it 'raises an error' do
+  #       stub_request(:get, 'https://wd3-impl-services1.workday.com/ccx/service/customreport2/tenant/INT003_ISU/CR_INT003_Commercial_Agreement_Cost_Center_and_Revenue_Category')
+  #         .with(headers: { 'Authorization' => 'Basic dXNlcjpwYXNzd29yZA==' })
+  #         .to_return(status: 500, body: '')
 
-        expect { subject.tax_code_ids }.to raise_error(Workday::ConnectionError)
-      end
-    end
-  end
+  #       expect { subject.tax_code_ids }.to raise_error(Workday::ConnectionError)
+  #     end
+  #   end
+  # end
 end

--- a/spec/models/workday/submit_invoice_adjustment_spec.rb
+++ b/spec/models/workday/submit_invoice_adjustment_spec.rb
@@ -86,11 +86,11 @@ RSpec.describe Workday::SubmitInvoiceAdjustment do
         ).to eq 'Revenue_Category_WID'
       end
 
-      it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
-        expect(
-          text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
-        ).to eq 'GBC20'
-      end
+      # it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
+      #   expect(
+      #     text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
+      #   ).to eq 'GBC20'
+      # end
     end
 
     describe 'when the invoice total is over £5000' do

--- a/spec/models/workday/submit_invoice_request.rb
+++ b/spec/models/workday/submit_invoice_request.rb
@@ -86,11 +86,11 @@ RSpec.describe Workday::SubmitInvoice do
         ).to eq 'Revenue_Category_WID'
       end
 
-      it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
-        expect(
-          text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
-        ).to eq 'GBC20'
-      end
+      # it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
+      #   expect(
+      #     text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
+      #   ).to eq 'GBC20'
+      # end
     end
 
     def text_at_xpath(xpath)

--- a/spec/models/workday/submit_reversal_invoice_adjustment_spec.rb
+++ b/spec/models/workday/submit_reversal_invoice_adjustment_spec.rb
@@ -87,11 +87,11 @@ RSpec.describe Workday::SubmitReversalInvoiceAdjustment do
         ).to eq 'Revenue_Category_WID'
       end
 
-      it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
-        expect(
-          text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
-        ).to eq 'GBC20'
-      end
+      # it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
+      #   expect(
+      #     text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
+      #   ).to eq 'GBC20'
+      # end
     end
 
     describe 'when the invoice total is over £5000' do

--- a/spec/models/workday/submit_reversal_invoice_spec.rb
+++ b/spec/models/workday/submit_reversal_invoice_spec.rb
@@ -87,11 +87,11 @@ RSpec.describe Workday::SubmitReversalInvoice do
         ).to eq 'Revenue_Category_WID'
       end
 
-      it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
-        expect(
-          text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
-        ).to eq 'GBC20'
-      end
+      # it 'sets Tax_Code_Reference//ID as the tax code Workday ID for the Framework' do
+      #   expect(
+      #     text_at_xpath("//ns0:Tax_Code_Reference//ns0:ID[@ns0:type='Tax_Code_ID']")
+      #   ).to eq 'GBC20'
+      # end
     end
 
     def text_at_xpath(xpath)


### PR DESCRIPTION
## Description
Commented out tax_code_id related code and specs to support to support research spike

## Why was the change made?
Kainos and finance may apply a different approach to determining correct tax code and applicability.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

N/A

## How was the change tested?
Ran specs.
