### PR TITLE
fix/rmi-519 export issues fix

### DIFF
--- a/app/jobs/submission_management_charge_calculation_job.rb
+++ b/app/jobs/submission_management_charge_calculation_job.rb
@@ -47,6 +47,10 @@ class SubmissionManagementChargeCalculationJob < ApplicationJob
       entry.update! management_charge: framework_definition.calculate_management_charge(entry)
     end
 
+    @submission.staging_entries.invoices.find_each do |staging_entry|
+      staging_entry.update! management_charge: framework_definition.calculate_management_charge(staging_entry)
+    end
+
     @submission.update!(management_charge_total: @submission.entries.invoices.sum(:management_charge))
     @submission.ready_for_review!
   end

--- a/app/models/data_warehouse_export.rb
+++ b/app/models/data_warehouse_export.rb
@@ -29,7 +29,9 @@ class DataWarehouseExport < ApplicationRecord
   end
 
   def clear_records_from_staging_table
-    SubmissionEntriesStage.where(updated_at: date_range).delete_all
+    relevant_states = %w[completed validation_failed replaced ingest_failed management_charge_calculation_failed]
+    submission_scope = Submission.where(updated_at: date_range, aasm_state: relevant_states)
+    SubmissionEntriesStage.joins(:submission).merge(submission_scope).delete_all
   end
 
   private

--- a/spec/jobs/submission_management_charge_calculation_job_spec.rb
+++ b/spec/jobs/submission_management_charge_calculation_job_spec.rb
@@ -7,6 +7,15 @@ RSpec.describe SubmissionManagementChargeCalculationJob do
     let!(:invoice_entry_1) { FactoryBot.create(:invoice_entry, :valid, submission: submission, total_value: 1235.99) }
     let!(:invoice_entry_2) { FactoryBot.create(:invoice_entry, :valid, submission: submission, total_value: 123.45) }
     let!(:order_entry) { FactoryBot.create(:order_entry, :valid, submission: submission, total_value: 123.45) }
+    let!(:staging_invoice_entry_1) do
+      FactoryBot.create(:invoice_entry_stage, :valid, submission: submission, total_value: 1235.99)
+    end
+    let!(:staging_invoice_entry_2) do
+      FactoryBot.create(:invoice_entry_stage, :valid, submission: submission, total_value: 123.45)
+    end
+    let!(:staging_order_entry) do
+      FactoryBot.create(:order_entry_stage, :valid, submission: submission, total_value: 123.45)
+    end
     let(:definition_source_arg) { framework.definition_source }
 
     context 'framework definition source has not changed since the job was enqueued' do
@@ -16,6 +25,12 @@ RSpec.describe SubmissionManagementChargeCalculationJob do
         expect(invoice_entry_1.reload.management_charge).to eq 18.5398
         expect(invoice_entry_2.reload.management_charge).to eq 1.8517
         expect(order_entry.reload.management_charge).to be_nil
+      end
+
+      it 'calculates the management charge for the submission invoice staging entries' do
+        expect(staging_invoice_entry_1.reload.management_charge).to eq 18.5398
+        expect(staging_invoice_entry_2.reload.management_charge).to eq 1.8517
+        expect(staging_order_entry.reload.management_charge).to be_nil
       end
 
       it 'updates the submission with the management charge total' do


### PR DESCRIPTION
## Description
Fix for the clear staging table method and missing management_charge from staging entries table.
https://crowncommercialservice.atlassian.net/browse/RMI-519

## Why was the change made?
Some submissions are not being exported in the invoices / contracts extracts, also ManagementChargeValue field for invoice submission entries mising from exports.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manual and unit testing.
