### PR TITLE
RMI-228 manifest update

### DIFF
--- a/CF/manifest-template.yml
+++ b/CF/manifest-template.yml
@@ -22,6 +22,7 @@ applications:
       - SKYLIGHT
       - WORKDAY_API
       - AZURE
+      - NOTIFY_API
     env:
       RAILS_ENV: production
       RAILS_MAX_THREADS: 5

--- a/CF/sidekiq-manifest-template.yml
+++ b/CF/sidekiq-manifest-template.yml
@@ -21,6 +21,7 @@ applications:
       - SKYLIGHT
       - WORKDAY_API
       - AZURE
+      - NOTIFY_API
     env:
       RAILS_ENV: production
       RAILS_MAX_THREADS: SIDEKIQ_CONCURRENCY


### PR DESCRIPTION
## Description
Added notify to list of user-provided services in manifests
https://crowncommercialservice.atlassian.net/browse/RMI-228

## Why was the change made?
Error in staging caused, I believe, by api key being set as env var rather than credential in vcap.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
N/A
