### PR TITLE
RMI-401-Replace-Framework-Terminology

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 ## [release-133] - 2022-09-29
 
-- RMI
+- RMI-401: Replaced UI instaces of "Framework" with "Agreement", to web pages, or where it will be seen on the site.
+- RMI-353: Add additional year filter to the completed tasks page.
+- RMI-522: Include Glassbox into the cookie configuration and page.
 
 ## [release-132] - 2022-08-16
 
@@ -886,6 +888,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-133]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-132...release-133
 [release-132]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-131...release-132
 [release-131]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-130...release-131
 [release-130]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-129...release-130

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [release-133] - 2022-09-29
+
+- RMI
+
 ## [release-132] - 2022-08-16
 
 - RMI-508: allow admin users to dowload customer effort scores

--- a/app/views/admin/agreements/confirm_activation.html.haml
+++ b/app/views/admin/agreements/confirm_activation.html.haml
@@ -9,7 +9,7 @@
     %p
       This supplier will be able to report management information on the
       = @framework.name
-      framework and will receive a new task at the next submission window.
+      agreement and will receive a new task at the next submission window.
       This supplier can be deactivated at any time.
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/admin/agreements/confirm_deactivation.html.haml
+++ b/app/views/admin/agreements/confirm_deactivation.html.haml
@@ -9,7 +9,7 @@
     %p
       This supplier will no longer be able to report management information on the
       = @framework.name
-      framework and will not be asked to report any more returns. This supplier can be reactivated at any time.
+      agreement and will not be asked to report any more returns. This supplier can be reactivated at any time.
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/admin/frameworks/edit.html.haml
+++ b/app/views/admin/frameworks/edit.html.haml
@@ -8,7 +8,7 @@
       %fieldset.govuk-fieldset
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
           %h2.govuk-fieldset__heading
-            Edit framework definition
+            Edit agreement definition
 
         = render partial: 'shared/error_summary', locals: { entity: @framework } if @framework.errors.present?
 

--- a/app/views/admin/frameworks/index.html.haml
+++ b/app/views/admin/frameworks/index.html.haml
@@ -44,7 +44,7 @@
         
   - else
     %p
-      No frameworks.
+      No agreements.
 
 :javascript
   var frameworkStatusCheckBoxes = document.querySelectorAll('#framework_status_checkboxes');

--- a/app/views/admin/frameworks/new.html.haml
+++ b/app/views/admin/frameworks/new.html.haml
@@ -1,7 +1,7 @@
 .govuk-grid-row
   .govuk-grid-column-full
     %h1.govuk-heading-xl
-      New framework
+      New agreement
 
 = simple_form_for [:admin, @framework] do |form|
   %fieldset.govuk-fieldset

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -57,4 +57,4 @@
           %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
             %h2.govuk-fieldset__heading
               Publish
-          = form.button :submit, value: 'Publish framework'
+          = form.button :submit, value: 'Publish agreement'

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -52,7 +52,7 @@
         .results{id: 'frameworks-table'}= render 'show_frameworks', frameworks: @frameworks
     -else
       %p
-        No frameworks for
+        No agreements for
         = @supplier.name
     .govuk-grid-row
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -28,7 +28,7 @@ en:
       invalid_urn: 'is not a recognised URN'
       invalid_ingested_date: 'must be in the format dd/mm/yyyy'
       invalid_optional_ingested_date: 'must be in the format dd/mm/yyyy or left blank'
-      invalid_lot_number: 'is not included in the supplier agreement agreement'
+      invalid_lot_number: 'is not included in the supplier framework agreement'
       invalid_dependent_field: '"%{value}" is not a valid %{attr} for the given %{parent_field_name} of "%{parent_field_value}". Please refer to the lookups tab in the template.'
       error_adding_user_to_auth0: 'There was an error adding the user to Auth0. Please try again.'
       missing_template_file: 'Missing template file'

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2,7 +2,7 @@
 en:
   admin:
     frameworks:
-      cannot_change: 'This framework has been published and cannot be edited'
+      cannot_change: 'This agreement has been published and cannot be edited'
 
   activerecord:
     attributes:
@@ -28,7 +28,7 @@ en:
       invalid_urn: 'is not a recognised URN'
       invalid_ingested_date: 'must be in the format dd/mm/yyyy'
       invalid_optional_ingested_date: 'must be in the format dd/mm/yyyy or left blank'
-      invalid_lot_number: 'is not included in the supplier framework agreement'
+      invalid_lot_number: 'is not included in the supplier agreement agreement'
       invalid_dependent_field: '"%{value}" is not a valid %{attr} for the given %{parent_field_name} of "%{parent_field_value}". Please refer to the lookups tab in the template.'
       error_adding_user_to_auth0: 'There was an error adding the user to Auth0. Please try again.'
       missing_template_file: 'Missing template file'

--- a/spec/features/admin_can_add_a_framework_spec.rb
+++ b/spec/features/admin_can_add_a_framework_spec.rb
@@ -26,12 +26,12 @@ RSpec.feature 'Admin can add a framework' do
         # When I visit the frameworks page
         visit admin_frameworks_path
         # Then I should see no frameworks
-        expect(page).to have_text('No frameworks')
+        expect(page).to have_text('No agreements')
 
         # And I click 'new framework'
         click_link 'New Framework'
         # Then I should see a "new framework" page
-        expect(page).to have_text('New framework')
+        expect(page).to have_text('New agreement')
 
         # When I paste a valid framework
         fill_in 'Definition', with: valid_source
@@ -88,7 +88,7 @@ RSpec.feature 'Admin can add a framework' do
       # And I click 'new framework'
       click_link 'New Framework'
       # Then I should see a "new framework" page
-      expect(page).to have_text('New framework')
+      expect(page).to have_text('New agreement')
 
       # When I paste an invalid framework
       fill_in 'Definition', with: invalid_source
@@ -112,7 +112,7 @@ RSpec.feature 'Admin can add a framework' do
       # And I click 'new framework'
       click_link 'New Framework'
       # Then I should see a "new framework" page
-      expect(page).to have_text('New framework')
+      expect(page).to have_text('New agreement')
 
       # When I paste an invalid framework
       fill_in 'Definition', with: invalid_source

--- a/spec/features/admin_can_edit_a_framework_spec.rb
+++ b/spec/features/admin_can_edit_a_framework_spec.rb
@@ -53,7 +53,7 @@ RSpec.feature 'Admin can edit a framework' do
         # When I click on Edit definition
         click_link('Edit definition')
         # Then I should see an edit page for the framework definition
-        expect(page).to have_content('Edit framework definition')
+        expect(page).to have_content('Edit agreement definition')
         # When I change the framework definition
         fill_in 'Definition source', with: edited_source
         # And I click "Save definition"

--- a/spec/features/admin_can_publish_a_framework_spec.rb
+++ b/spec/features/admin_can_publish_a_framework_spec.rb
@@ -30,7 +30,7 @@ RSpec.feature 'Admin can edit a framework' do
 
     scenario 'everything is fine' do
       visit admin_framework_path(framework)
-      click_button('Publish framework')
+      click_button('Publish agreement')
       expect(page).to have_content('Framework published successfully')
       expect(framework.lots.count).to eq(2)
     end


### PR DESCRIPTION
## Description
RMI-401

## Why was the change made?
"Framework" usage is being refined out by CCS, and so this replaces any UI viewable instances with "Agreement", as required.

## Are there any dependencies required for this change?
No, but same changes also made in the Front End.

## What type of change is it?

 [X] New feature 

## How was the change tested?
Non required, as there are no functional or server changes, they are only superficial changes.