### PR TITLE
Feature/rmi 30 update supplier tasks tab

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -3,4 +3,18 @@ window.onload = function() {
   document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
 
   window.GOVUKFrontend.initAll()
+
+  $("body").on('click', '.rmi-govuk-table-accordion-icon', function( event ) {
+    var tableIconVal = this.getAttribute("data-table-icon");
+
+    var tableAccContent = document.querySelector("[data-table-accordion='" + tableIconVal + "']");
+
+    if (tableAccContent.classList.contains("rmi-table-accordion-content--expanded")) {
+      tableAccContent.classList.remove("rmi-table-accordion-content--expanded");
+      this.classList.remove("rmi-govuk-table-accordion-expanded")
+    } else {
+      tableAccContent.classList.add("rmi-table-accordion-content--expanded");
+      this.classList.add("rmi-govuk-table-accordion-expanded")
+    }
+  })
 };

--- a/app/assets/stylesheets/components/accordion/_accordion.scss
+++ b/app/assets/stylesheets/components/accordion/_accordion.scss
@@ -107,3 +107,31 @@
 .js-enabled .ccs-accordion__section-button {
     color: #0B0C0C;
 }
+
+.rmi-table-accordion-content {
+    display:none
+    }
+
+    .rmi-table-accordion-content--expanded {
+    display: table-row-group;
+    }
+
+.rmi-govuk-table-accordion-expanded::after {
+    height: 0!important;
+  }
+
+.rmi-govuk-table__body .govuk-accordion__icon {
+
+    right: 0px!important;
+    top: 22px!important;
+
+    &:before {
+        height: 0!important;
+        border-width: 1px!important;
+    }
+
+    &:after {
+        width: 0!important;
+        border-width: 1px!important;
+    }
+}

--- a/app/assets/stylesheets/components/table/_table.scss
+++ b/app/assets/stylesheets/components/table/_table.scss
@@ -4,3 +4,6 @@
   @include govuk-font($size: false);
 }
 
+.rmi-govuk-table__cell {
+  position: relative;
+}

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -65,6 +65,10 @@ dependent: :nullify
     Date.new(period_year, period_month)
   end
 
+  def past_submissions
+    submissions.where('created_at < ?', active_submission.updated_at).order(updated_at: :desc) if active_submission
+  end
+
   # Returns true when the task is yet to be completed by the Supplier
   def incomplete?
     !completed? && !correcting?

--- a/app/views/admin/suppliers/_show_tasks.html.haml
+++ b/app/views/admin/suppliers/_show_tasks.html.haml
@@ -4,11 +4,11 @@
       %th.govuk-table__header Task
       %th.govuk-table__header.govuk-table__header--numeric Management Charge
       %th.govuk-table__header Submitted
-      %th.govuk-table__header Status
+      %th.govuk-table__header{:colspan => 2} Status
       %th.govuk-table__header Return
       %th.govuk-table__header Errors
-  %tbody.govuk-table__body
-    = render(collection: @tasks, partial: "task")
+      %th.govuk-table__header{:colspan => 2}
+  = render(collection: @tasks, partial: "task")
 %nav.pagination.ccs-pagination{"aria-label" => "Pagination", :role => "navigation"}
   #task_pagination_summary.ccs-pagination__summary= page_entries_info @tasks, entry_name: "task"
   #task_pagination= paginate @tasks, :param_name => "task_page", remote: true

--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -1,31 +1,64 @@
-%tr.govuk-table__row
-  %td.govuk-table__cell
-    = task.framework.short_name
-    %br/
-    %small
-      = task.period_date.to_s(:month_year)
-  - if task.active_submission
-    %td.govuk-table__cell.govuk-table__cell--numeric
-      - unless task.active_submission.management_charge.to_f.zero? && task.active_submission.total_spend.to_f.zero?
-        = number_to_currency(task.active_submission.management_charge, unit: '£')
-        %br/
+%tbody.govuk-table__body.rmi-govuk-table__body
+  %tr.govuk-table__row
+    %td.govuk-table__cell
+      = task.framework.short_name
+      %br/
+      %small
+        = task.period_date.to_s(:month_year)
+    - if task.active_submission
+      %td.govuk-table__cell.govuk-table__cell--numeric
+        - unless task.active_submission.management_charge.to_f.zero? && task.active_submission.total_spend.to_f.zero?
+          = number_to_currency(task.active_submission.management_charge, unit: '£')
+          %br/
+          %small
+            from
+            = number_to_currency(task.active_submission.total_spend, unit: '£')
+            spend
+      %td.govuk-table__cell
+        = task.active_submission.created_at.to_s(:date_with_utc_time)
+        %br
         %small
-          from
-          = number_to_currency(task.active_submission.total_spend, unit: '£')
-          spend
-    %td.govuk-table__cell
-      = task.active_submission.created_at.to_s(:date_with_utc_time)
-    %td.govuk-table__cell
-      = task.active_submission.aasm_state.titlecase
-    %td.govuk-table__cell
-      - if task.active_submission.files.any? && task.active_submission.files.first.file.attached?
-        = link_to 'Download', admin_task_submission_download_path(task, task.active_submission)
-    %td.govuk-table__cell
-      = link_to 'View', admin_supplier_submission_path(task.supplier, task.active_submission) if task.active_submission.validation_failed?
-  - else
-    %td.govuk-table__cell
-    %td.govuk-table__cell
-    %td.govuk-table__cell
-      = task.status.titlecase
-    %td.govuk-table__cell
-    %td.govuk-table__cell
+          = task.active_submission.created_by.email.scan(/.{1,20}/).join("\n")
+      %td.govuk-table__cell{:colspan => 2}
+        %small
+          = task.active_submission.aasm_state.titlecase
+      %td.govuk-table__cell
+        - if task.active_submission.files.any? && task.active_submission.files.first.file.attached?
+          = link_to 'Download', admin_task_submission_download_path(task, task.active_submission)
+      %td.govuk-table__cell
+        = link_to 'View', admin_supplier_submission_path(task.supplier, task.active_submission) if task.active_submission.validation_failed?
+      %td.govuk-table__cell.rmi-govuk-table__cell{:colspan => 2}
+        - if task.past_submissions && task.past_submissions.any?
+          %span.rmi-govuk-table-accordion-icon.govuk-accordion__icon{"data-table-icon" => task.id }
+    - else
+      %td.govuk-table__cell
+      %td.govuk-table__cell
+      %td.govuk-table__cell{:colspan => 2}
+        = task.status.titlecase
+      %td.govuk-table__cell
+      %td.govuk-table__cell
+      %td.govuk-table__cell{:colspan => 2}
+  - if task.past_submissions && task.past_submissions.any?
+    %tbody.rmi-table-accordion-content{"data-table-accordion" => task.id }
+      -task.past_submissions.each do |submission|
+        %tr
+          %td.govuk-table__cell
+          %td.govuk-table__cell.govuk-table__cell--numeric
+            - unless submission.management_charge.to_f.zero? && submission.total_spend.to_f.zero?
+              = number_to_currency(submission.management_charge, unit: '£')
+              %br/
+              %small
+                from
+                = number_to_currency(submission.total_spend, unit: '£')
+                spend
+          %td.govuk-table__cell
+            = submission.created_at.to_s(:date_with_utc_time)
+            %br
+            %small
+              = submission.created_by.email.scan(/.{1,20}/).join("\n")
+          %td.govuk-table__cell{:colspan => 2}
+            %small
+              = submission.aasm_state.titlecase
+          %td.govuk-table__cell
+          %td.govuk-table__cell
+          %td.govuk-table__cell{:colspan => 2}

--- a/spec/features/admin_can_view_submission_errors_spec.rb
+++ b/spec/features/admin_can_view_submission_errors_spec.rb
@@ -2,12 +2,15 @@ require 'rails_helper'
 
 RSpec.feature 'Admin users can' do
   before do
+    user = FactoryBot.create(:user, name: 'User One', email: 'email_one@ccs.co.uk')
     supplier = FactoryBot.create(:supplier, name: 'First Supplier')
+    FactoryBot.create(:membership, user: user, supplier: supplier)
     task = FactoryBot.create(:task, supplier: supplier)
     FactoryBot.create(
       :submission_with_invalid_entries,
       supplier: supplier,
-      task: task
+      task: task,
+      created_by: user
     )
     sign_in_as_admin
   end

--- a/spec/features/view_supplier_details_spec.rb
+++ b/spec/features/view_supplier_details_spec.rb
@@ -41,7 +41,8 @@ RSpec.feature 'Viewing a supplier' do
       :task, period_month: 12, period_year: 2018, supplier: supplier, framework: framework, status: :completed
     )
 
-    FactoryBot.create(:submission, supplier: supplier, framework: framework, task: task, created_by: user) do |submission|
+    FactoryBot.create(:submission, supplier: supplier, framework: framework, task: task,
+created_by: user) do |submission|
       FactoryBot.create(:submission_file, :with_attachment, submission: submission, filename: 'test.xlsx')
     end
 
@@ -54,7 +55,6 @@ RSpec.feature 'Viewing a supplier' do
   end
 
   scenario 'shows paginated list of the users linked to the supplier' do
-
     visit admin_supplier_path(supplier)
     expect(page).to have_content 'Active?'
     expect(page).to have_content 'Displaying 1 user'

--- a/spec/features/view_supplier_details_spec.rb
+++ b/spec/features/view_supplier_details_spec.rb
@@ -4,6 +4,7 @@ RSpec.feature 'Viewing a supplier' do
   let!(:supplier) { FactoryBot.create(:supplier, name: 'Test Supplier Ltd') }
   let!(:framework) { FactoryBot.create(:framework, name: 'Test Framework', short_name: 'RM0000') }
   let!(:agreement) { FactoryBot.create(:agreement, supplier: supplier, framework: framework) }
+  let!(:user) { FactoryBot.create(:user, name: 'User One', email: 'email_one@ccs.co.uk', suppliers: [supplier]) }
 
   before { sign_in_as_admin }
 
@@ -28,7 +29,7 @@ RSpec.feature 'Viewing a supplier' do
       :task, period_month: 12, period_year: 2018, supplier: supplier, framework: framework, status: :in_progress
     )
     FactoryBot.create(
-      :submission_with_validated_entries, supplier: supplier, framework: framework, task: task
+      :submission_with_validated_entries, supplier: supplier, framework: framework, task: task, created_by: user
     )
 
     visit admin_supplier_path(supplier)
@@ -40,7 +41,7 @@ RSpec.feature 'Viewing a supplier' do
       :task, period_month: 12, period_year: 2018, supplier: supplier, framework: framework, status: :completed
     )
 
-    FactoryBot.create(:submission, supplier: supplier, framework: framework, task: task) do |submission|
+    FactoryBot.create(:submission, supplier: supplier, framework: framework, task: task, created_by: user) do |submission|
       FactoryBot.create(:submission_file, :with_attachment, submission: submission, filename: 'test.xlsx')
     end
 
@@ -53,7 +54,6 @@ RSpec.feature 'Viewing a supplier' do
   end
 
   scenario 'shows paginated list of the users linked to the supplier' do
-    FactoryBot.create(:user, suppliers: [supplier])
 
     visit admin_supplier_path(supplier)
     expect(page).to have_content 'Active?'
@@ -68,7 +68,6 @@ framework: framework)
       FactoryBot.create(:user, suppliers: [supplier])
     end
     FactoryBot.create(:task, period_month: 12, period_year: 2017, supplier: supplier, framework: framework)
-    FactoryBot.create(:user, suppliers: [supplier])
 
     visit admin_supplier_path(supplier)
     click_link('Next »', match: :first)


### PR DESCRIPTION
## Description
Admin section: Update the Suppliers Page - Tasks tab - to include "Replaced" tasks
https://crowncommercialservice.atlassian.net/browse/RMI-30

## Why was the change made?
To allow admin to view a history of supplier task submissions and help the customer with queries.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manual and feature tests
