### PR TITLE
RMI-30 update

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -66,7 +66,7 @@ dependent: :nullify
   end
 
   def past_submissions
-    submissions.where('created_at < ?', active_submission.updated_at).order(updated_at: :desc) if active_submission
+    submissions.where(aasm_state: :replaced).order(updated_at: :desc)
   end
 
   # Returns true when the task is yet to be completed by the Supplier


### PR DESCRIPTION
## Description
Applied QA feedback re: only showing past submissions with aasm_state 'replaced'
https://crowncommercialservice.atlassian.net/browse/RMI-30

## Why was the change made?
To allow admin to view a history of supplier task submissions and help the customer with queries.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manual and feature tests
