### PR TITLE
Feature/rmi 553 unfinished tasks filter order

### DIFF
--- a/app/controllers/admin/unfinished_tasks_controller.rb
+++ b/app/controllers/admin/unfinished_tasks_controller.rb
@@ -1,6 +1,7 @@
 class Admin::UnfinishedTasksController < AdminController
   def index
-    @tasks = Task.incomplete.latest_submission_with_state(unfinished_submissions_relation(params[:status])).includes(:supplier).order("suppliers.name asc").page(params[:page]).per(12)
+    @tasks = Task.incomplete.latest_submission_with_state(unfinished_submissions_relation(params[:status]))
+                 .includes(:supplier).order('suppliers.name asc').page(params[:page]).per(12)
 
     respond_to do |format|
       format.html
@@ -12,7 +13,7 @@ class Admin::UnfinishedTasksController < AdminController
 
   def unfinished_submissions_relation(aasm_states)
     if aasm_states.nil?
-      aasm_states = %i[validation_failed ingest_failed in_review]
+      %i[validation_failed ingest_failed in_review]
     else
       aasm_states
     end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -21,6 +21,12 @@ class Task < ApplicationRecord
 
   scope :incomplete, -> { where.not(status: 'completed') }
 
+  scope :latest_submission_with_state, lambda { |status_param|
+    joins(:submissions)
+      .where('submissions.created_at = (SELECT MAX(submissions.created_at) FROM submissions WHERE submissions.task_id = tasks.id)')
+      .where('submissions.aasm_state IN (?)', status_param)
+  }
+
   validates :status, presence: true
   validates :period_year, presence: true
   validates :period_month,

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -21,11 +21,13 @@ class Task < ApplicationRecord
 
   scope :incomplete, -> { where.not(status: 'completed') }
 
+  # rubocop:disable Metrics/LineLength
   scope :latest_submission_with_state, lambda { |status_param|
     joins(:submissions)
       .where('submissions.created_at = (SELECT MAX(submissions.created_at) FROM submissions WHERE submissions.task_id = tasks.id)')
       .where('submissions.aasm_state IN (?)', status_param)
   }
+  # rubocop:enable Metrics/LineLength
 
   validates :status, presence: true
   validates :period_year, presence: true

--- a/app/views/admin/unfinished_tasks/_tasks_table.html.haml
+++ b/app/views/admin/unfinished_tasks/_tasks_table.html.haml
@@ -1,4 +1,4 @@
-%table.govuk-table{:class => 'govuk-!-margin-top-7'}
+%table.govuk-table
   %thead.govuk-table__head
     %tr.govuk-table__row
       %th.govuk-table__header Supplier
@@ -29,3 +29,6 @@
             = link_to 'Download', admin_task_submission_download_path(task, task.latest_submission)
         %td.govuk-table__cell
           = link_to 'View', admin_supplier_submission_path(task.supplier, task.latest_submission) if task.latest_submission.validation_failed?
+%nav.pagination.ccs-pagination{"aria-label" => "Pagination", :role => "navigation"}
+  #unfinished_task_pagination_summary.ccs-pagination__summary= page_entries_info @tasks, entry_name: "task"
+  #unfinished_task_pagination= paginate @tasks, :param_name => "page", remote: true

--- a/app/views/admin/unfinished_tasks/index.html.haml
+++ b/app/views/admin/unfinished_tasks/index.html.haml
@@ -4,8 +4,51 @@
       Unfinished tasks
 
 .govuk-grid-row
-  .govuk-grid-column-full
-    .results{id: 'unfinished-tasks-table'}= render 'tasks_table', partial: "task"
-    %nav.pagination.ccs-pagination{"aria-label" => "Pagination", :role => "navigation"}
-      #unfinished_task_pagination_summary.ccs-pagination__summary= page_entries_info @tasks, entry_name: "task"
-      #unfinished_task_pagination= paginate @tasks, :param_name => "page", remote: true
+  = form_tag(admin_unfinished_tasks_path, method: :get, enforce_utf8: false, remote: :true, id: 'task_status_filter') do
+    .govuk-grid-column-one-quarter
+      .ccs-filters-intro{class: 'govuk-!-padding-1'}
+        = link_to 'Clear filter', admin_unfinished_tasks_path, method: :get, enforce_utf8: false, id: 'clear_filter', class: 'ccs-clear-filters', 'aria-label' => 'Clear filters'
+        %h2.govuk-heading-m Apply filter
+      #accordion-with-summary-sections.ccs-accordion.ccs-accordion--clean{"data-module" => "govuk-accordion"}
+        .govuk-accordion__section.ccs-accordion__section--clean.govuk-form-group.govuk-form-group--enclosure.ccs-form-group--enclosure--tight
+          .govuk-accordion__section-header
+            %h2.govuk-accordion__section-heading
+              %span#accordion-with-summary-sections-heading-1.govuk-accordion__section-button.ccs-accordion__section-button
+                %h3.govuk-heading-s
+                  Filter Status
+          #accordion-with-summary-sections-content-1.govuk-accordion__section-content{"aria-labelledby" => "accordion-with-summary-sections-heading-1"}
+            .govuk-form-group
+              %fieldset.govuk-fieldset
+                %legend.govuk-fieldset__legend.govuk-fieldset__legend--m
+                .govuk-checkboxes{id: 'task-status-checkboxes'}            
+                  .govuk-checkboxes__item.govuk-checkboxes__item--small
+                    = check_box_tag('status[]', 'validation_failed', false,
+                      class: 'govuk-checkboxes__input govuk-checkboxes__input--small',
+                      id: 'task_status_validation_failed')
+                    = label_tag "task_status_validation_failed", "Validation Failed", class: 'govuk-checkboxes__label'
+                  .govuk-checkboxes__item.govuk-checkboxes__item--small
+                    = check_box_tag('status[]', 'ingest_failed', false,
+                      class: 'govuk-checkboxes__input govuk-checkboxes__input--small',
+                      id: 'task_status_ingest_failed')
+                    = label_tag "task_status_ingest_failed", "Ingest Failed", class: 'govuk-checkboxes__label'
+                  .govuk-checkboxes__item.govuk-checkboxes__item--small
+                    = check_box_tag('status[]', 'in_review', false,
+                      class: 'govuk-checkboxes__input govuk-checkboxes__input--small',
+                      id: 'task_status_in_review')
+                    = label_tag "task_status_in_review", "In Review", class: 'govuk-checkboxes__label'
+      %noscript
+        %p
+          Please enable javascript to use filters.
+
+  .govuk-grid-column-three-quarters
+    .results{id: 'unfinished-tasks-table'}= render 'tasks_table', tasks: @tasks
+
+:javascript
+  var unfinishedTaskFilterCheckBoxes = document.querySelectorAll("#task-status-checkboxes");
+  var unfinishedTaskFilterForm = document.getElementById('task_status_filter');
+
+  for (const check of unfinishedTaskFilterCheckBoxes) {
+    check.addEventListener( 'change', function() {
+      Rails.fire(unfinishedTaskFilterForm, 'submit');
+    });
+  }

--- a/spec/features/admin_can_list_unfinished_tasks_spec.rb
+++ b/spec/features/admin_can_list_unfinished_tasks_spec.rb
@@ -36,7 +36,7 @@ aasm_state: state) do |submission|
     find(:xpath, "(//a[text()='Download'])[1]").click
 
     expect(page.response_headers['Content-Disposition']).to match(/^attachment/)
-    expect(page.response_headers['Content-Disposition']).to match(/RM0000 Test Supplier Ltd %28April 2019%29\.xlsx/)
+    expect(page.response_headers['Content-Disposition']).to match(/RM0000 Test Supplier Ltd %28February 2019%29\.xlsx/)
     expect(page.body).to include File.open(Rails.root.join('spec', 'fixtures', 'test.xlsx'), 'r:ASCII-8BIT', &:read)
   end
 end


### PR DESCRIPTION
## Description
Add filter and update sorting on Unfinished Tasks page in the Admin section
https://crowncommercialservice.atlassian.net/browse/RMI-553

## Why was the change made?
Improve admin user experience

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual testing
