### PR TITLE
RMI-527

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -116,6 +116,7 @@ Metrics/AbcSize:
         - 'lib/console_helpers.rb'
         - 'app/models/submission_completion.rb'
         - 'app/controllers/admin/suppliers_controller.rb'
+        - 'app/controllers/v1/tasks_controller.rb'
 
 Layout/LineLength:
     Max: 120

--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -6,6 +6,7 @@ class V1::TasksController < APIController
     tasks = tasks.includes(:supplier).includes(requested_associations)
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
     tasks = tasks.where(framework_id: params.dig(:filter, :framework_id)) if params.dig(:filter, :framework_id)
+    tasks = tasks.order('due_on DESC', 'frameworks.name ASC') if requested_associations.include?(:framework)
 
     render jsonapi: tasks, include: params[:include], fields: sparse_field_params
   end
@@ -81,6 +82,7 @@ class V1::TasksController < APIController
   end
 
   def requested_associations
+    # pp "requested_associations:::::::::::::::::"
     params.fetch(:include, '').split(',').map(&:to_sym)
   end
 end


### PR DESCRIPTION
## Description
Change the way tasks are displayed on supplier home page
https://crowncommercialservice.atlassian.net/browse/RMI-527

## Why was the change made?
In order to have consistent way in which suppliers see the agreements.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Manually
