### PR TITLE
RMI-502

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -31,6 +31,8 @@ class V1::TasksController < APIController
   def no_business
     task = current_user.tasks.find(params[:id])
 
+    task.cancel_correction if task.correcting?
+
     if task.completed? && !correcting_submission?
       render jsonapi: task.active_submission
       return


### PR DESCRIPTION
## Description
Workday transaction was not reversed when a submission was replaced.
https://crowncommercialservice.atlassian.net/browse/RMI-502

## Why was the change made?
A supplier submitted an MI return and was invoiced, and then subsequently replaced that return and was invoiced again. However, the first invoice was not credited as intended.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
