### PR TITLE
Feature/rmi 596 fix for missed credit notes

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -110,7 +110,7 @@ class Submission < ApplicationRecord
   end
 
   def create_reversal_invoice?
-    !self.report_no_business? && self.management_charge != 0 && ENV['SUBMIT_INVOICES']
+    !report_no_business? && management_charge != 0 && ENV['SUBMIT_INVOICES']
   end
 
   def errors_for(sheet_name)

--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -110,7 +110,7 @@ class Submission < ApplicationRecord
   end
 
   def create_reversal_invoice?
-    invoice.present? && ENV['SUBMIT_INVOICES']
+    !self.report_no_business? && self.management_charge != 0 && ENV['SUBMIT_INVOICES']
   end
 
   def errors_for(sheet_name)

--- a/spec/models/submission_spec.rb
+++ b/spec/models/submission_spec.rb
@@ -27,8 +27,10 @@ RSpec.describe Submission do
   end
 
   describe '#replace_with_no_business state machine event' do
-    let(:submission) { FactoryBot.create(:completed_submission) } 
-    let(:submission_with_no_invoice) { FactoryBot.create(:submission_with_zero_management_charge, aasm_state: 'completed') }
+    let(:submission) { FactoryBot.create(:completed_submission) }
+    let(:submission_with_no_invoice) do
+      FactoryBot.create(:submission_with_zero_management_charge, aasm_state: 'completed')
+    end
     let(:correcting_user) { FactoryBot.create(:user) }
 
     it 'transitions from completed to replaced' do
@@ -85,7 +87,9 @@ RSpec.describe Submission do
 
   describe '#mark_as_replaced state machine event' do
     let(:submission) { FactoryBot.create(:completed_submission) }
-    let(:submission_with_no_invoice) { FactoryBot.create(:submission_with_zero_management_charge, aasm_state: 'completed') }
+    let(:submission_with_no_invoice) do
+      FactoryBot.create(:submission_with_zero_management_charge, aasm_state: 'completed')
+    end
     let(:correcting_user) { FactoryBot.create(:user) }
 
     it 'transitions from completed to replaced' do


### PR DESCRIPTION
## Description
Fix for edge case scenario in which following any kind of workday error or delay in generating invoices for submissions, credit note jobs were not being queued on resubmission
https://crowncommercialservice.atlassian.net/browse/RMI-596

## Why was the change made?
To prevent the issue outlined above

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Unit and manual testing
