### PR TITLE
RMI-647

### DIFF
--- a/app/models/workday/customer_invoice.rb
+++ b/app/models/workday/customer_invoice.rb
@@ -46,7 +46,7 @@ module Workday
           "#{base_url}/ccx/service/customreport2/#{Workday.tenant}/INT003_ISU/CR_Customer_Invoice_API?Customer_Invoice!WID=#{@workday_reference}"
         )
 
-        raise Workday::ConnectionError if result.status == 500
+        raise Workday::ConnectionError unless result.status == 200
 
         result
       end


### PR DESCRIPTION
## Description
View completed task page (Frontend) should still display given failed Workday call
https://crowncommercialservice.atlassian.net/browse/RMI-647

## Why was the change made?
Supplier completed task view not loading in certain circumstances

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
