### PR TITLE
Feature/rmi 694 prevent floating users

### DIFF
--- a/app/views/admin/users/show.html.haml
+++ b/app/views/admin/users/show.html.haml
@@ -38,11 +38,12 @@
             %tr.govuk-table__row
               %td.govuk-table__cell= link_to membership.supplier.name, admin_supplier_path(membership.supplier)
               %td.govuk-table__cell
-                %nav.govuk-table-actions{"aria-labelledby" => "table-actions-title-1"}
-                  %h3#table-actions-title-1.govuk-visually-hidden Row actions
-                  %ul.govuk-table-actions--actions
-                    %li.govuk-table-actions--action
-                      = link_to 'Unlink', admin_user_membership_path(@user, membership, return_to: 'user')
+                - if @user.multiple_suppliers?
+                  %nav.govuk-table-actions{"aria-labelledby" => "table-actions-title-1"}
+                    %h3#table-actions-title-1.govuk-visually-hidden Row actions
+                    %ul.govuk-table-actions--actions
+                      %li.govuk-table-actions--action
+                        = link_to 'Unlink', admin_user_membership_path(@user, membership, return_to: 'user')
     -else
       %p
         No suppliers linked to

--- a/spec/features/managing_user_memberships_spec.rb
+++ b/spec/features/managing_user_memberships_spec.rb
@@ -33,7 +33,7 @@ RSpec.feature 'Managing user memberships' do
       expect(page).to have_content('Supplier 2')
       expect(page).to have_content('Unlink')
 
-      click_link("Unlink", :match => :first)
+      click_link('Unlink', match: :first)
       click_on 'Unlink user'
 
       expect(page).to_not have_content('Supplier 1')

--- a/spec/features/managing_user_memberships_spec.rb
+++ b/spec/features/managing_user_memberships_spec.rb
@@ -17,13 +17,27 @@ RSpec.feature 'Managing user memberships' do
     expect(page).to have_content('Supplier 2')
   end
 
-  scenario 'removing a user from a supplier' do
-    visit admin_user_path(user)
-    expect(page).to have_content('Supplier 1')
-    click_on 'Unlink'
-    click_on 'Unlink user'
+  context 'user is linked to one supplier only' do
+    scenario 'admin cannot remove a user from a supplier' do
+      visit admin_user_path(user)
+      expect(page).to have_content('Supplier 1')
+      expect(page).to_not have_content('Unlink')
+    end
+  end
 
-    expect(page).to_not have_content('Supplier 1')
+  context 'user is linked to more than one supplier ' do
+    scenario 'admin can remove a user from a supplier' do
+      FactoryBot.create(:membership, user: user, supplier: supplier_2)
+      visit admin_user_path(user)
+      expect(page).to have_content('Supplier 1')
+      expect(page).to have_content('Supplier 2')
+      expect(page).to have_content('Unlink')
+
+      click_link("Unlink", :match => :first)
+      click_on 'Unlink user'
+
+      expect(page).to_not have_content('Supplier 1')
+    end
   end
 
   scenario 'searching for a supplier' do


### PR DESCRIPTION
## Description
[Prevent existing users from being linked to no suppliers](https://crowncommercialservice.atlassian.net/browse/RMI-694)

## Why was the change made?
To prevent floating users

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual testing
