### PR TITLE
Feature/rmi 686 get memberships

### DIFF
--- a/app/controllers/v2/memberships_controller.rb
+++ b/app/controllers/v2/memberships_controller.rb
@@ -1,0 +1,8 @@
+class V2::MembershipsController < ActionController::API
+  include ApiKeyAuthenticatable
+
+  def index
+    @memberships = Membership.all
+    render json: @memberships
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Rails.application.routes.draw do
   namespace :v2, defaults: { format: :json } do
     resources :users, only: :index
     resources :suppliers, only: :index
+    resources :memberships, only: :index
   end
 
   namespace :admin do

--- a/spec/requests/v2/memberships_spec.rb
+++ b/spec/requests/v2/memberships_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'V2::Memberships', type: :request do
+  let(:valid_api_key) { create(:api_key) }
+  let(:invalid_api_key) { 'invalid_key' }
+
+  describe 'GET /v2/memberships' do
+    context 'with valid API key' do
+      before do
+        create_list(:membership, 3)
+        get v2_memberships_path, headers: { 'API-Key' => valid_api_key.key }
+      end
+
+      it 'returns a list of memberships' do
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(3)
+      end
+    end
+
+    context 'with missing API key' do
+      before { get v2_memberships_path }
+
+      it 'returns unauthorized status' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['error']).to eq('API key is missing')
+      end
+    end
+
+    context 'with invalid API key' do
+      before { get v2_memberships_path, headers: { 'API-Key' => invalid_api_key } }
+
+      it 'returns unauthorized status' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['error']).to eq('API key is invalid')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
New GET endpoint for all memberships
https://crowncommercialservice.atlassian.net/browse/RMI-686

## Why was the change made?
To support internal organisation requirements

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Unit and manual testing