### PR TITLE
feature/rmi 700 improve task history loading

### DIFF
--- a/app/controllers/v1/tasks_controller.rb
+++ b/app/controllers/v1/tasks_controller.rb
@@ -6,6 +6,7 @@ class V1::TasksController < ApiController
     tasks = tasks.includes(:supplier).includes(requested_associations)
     tasks = tasks.where(status: params.dig(:filter, :status)) if params.dig(:filter, :status)
     tasks = tasks.where(framework_id: params.dig(:filter, :framework_id)) if params.dig(:filter, :framework_id)
+    tasks.order!(due_on: :desc)
 
     render jsonapi: tasks, include: params[:include], fields: sparse_field_params
   end


### PR DESCRIPTION
## Description
Added ordering to task api
https://crowncommercialservice.atlassian.net/browse/RMI-700

## Why was the change made?
Completed tasks page on supplier side taking too long to load

## Are there any dependencies required for this change?
no

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
