### PR TITLE
Feature/rmi 692 get agreement framework lots

### DIFF
--- a/app/controllers/v2/agreement_framework_lots_controller.rb
+++ b/app/controllers/v2/agreement_framework_lots_controller.rb
@@ -1,0 +1,8 @@
+class V2::AgreementFrameworkLotsController < ActionController::API
+  include ApiKeyAuthenticatable
+
+  def index
+    @agreement_framework_lots = AgreementFrameworkLot.all
+    render json: @agreement_framework_lots
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -66,6 +66,7 @@ Rails.application.routes.draw do
     resources :customers, only: :index
     resources :frameworks, only: :index
     resources :framework_lots, only: :index
+    resources :agreement_framework_lots, only: :index
   end
 
   namespace :admin do

--- a/spec/requests/v2/agreement_framework_lots_spec.rb
+++ b/spec/requests/v2/agreement_framework_lots_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe 'V2::AgreementFrameworkLots', type: :request do
+  let(:valid_api_key) { create(:api_key) }
+  let(:invalid_api_key) { 'invalid_key' }
+
+  describe 'GET /v2/agreement_framework_lots' do
+    context 'with valid API key' do
+      before do
+        create_list(:agreement_framework_lot, 5)
+        get v2_agreement_framework_lots_path, headers: { 'API-Key' => valid_api_key.key }
+      end
+
+      it 'returns a list of agreement framework lots' do
+        expect(response).to have_http_status(:ok)
+        expect(JSON.parse(response.body).size).to eq(5)
+      end
+    end
+
+    context 'with missing API key' do
+      before { get v2_agreement_framework_lots_path }
+
+      it 'returns unauthorized status' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['error']).to eq('API key is missing')
+      end
+    end
+
+    context 'with invalid API key' do
+      before { get v2_agreement_framework_lots_path, headers: { 'API-Key' => invalid_api_key } }
+
+      it 'returns unauthorized status' do
+        expect(response).to have_http_status(:unauthorized)
+        expect(JSON.parse(response.body)['error']).to eq('API key is invalid')
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Description
New GET endpoint for all agreement framework lots
https://crowncommercialservice.atlassian.net/browse/RMI-692

## Why was the change made?
To support internal organisation requirements

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Unit and manual testing
