### PR TITLE
Feature/nrmi 28 change banner to details component

### DIFF
--- a/app/assets/javascripts/main.js
+++ b/app/assets/javascripts/main.js
@@ -19,17 +19,18 @@ window.onload = function() {
   });
 
   $("body").on('click', '#markdown-preview-btn', function( event ) {
-    console.log("Inside previewBtn click function");
-    const text = document.getElementById("notification_notification_message").value;
-    console.log(text);
-    console.log(JSON.stringify({ text: text }));
+    const summary = document.getElementById("notification_summary").value;
+    const message = document.getElementById("notification_notification_message").value;
+    const previewContainer = document.getElementById('preview-container');
+    const data = { summary: summary, message: message }
+
     fetch('/admin/notifications/preview', {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
         'X-CSRF-Token': document.querySelector('[name="csrf-token"]').content 
       },
-      body: JSON.stringify({ text: text })
+      body: JSON.stringify(data)
     })
     .then(response => {
       if(response.ok) {
@@ -37,8 +38,10 @@ window.onload = function() {
       }
       throw new Error('Network response was not ok.');
     })
-    .then(data => {
-      document.getElementById("markdown-preview").innerHTML = data.html;
-    });
+    .then(html => {
+      previewContainer.classList.remove('govuk-visually-hidden');
+      document.getElementById("summary-preview").innerHTML = html.summary;
+      document.getElementById("markdown-preview").innerHTML = html.message;
+    })
   });
 };

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -14,13 +14,14 @@ class Admin::NotificationsController < AdminController
     renderer = CustomMarkdownRenderer.new
     markdown_parser = Redcarpet::Markdown.new(renderer)
     html = markdown_parser.render(notification_params[:notification_message])
-    @notification = Notification.new(notification_message: html, user: current_user['email'], published: true,
+    @notification = Notification.new(summary: notification_params[:summary], notification_message: html, user: current_user['email'], published: true,
                                      published_at: Time.zone.now)
     Notification.transaction do
       if @notification.save
         flash[:success] = 'Notification created successfully.'
         redirect_to admin_notifications_path
       else
+        @notification.assign_attributes(notification_message: notification_params[:notification_message])
         render action: :new
       end
     end
@@ -29,9 +30,9 @@ class Admin::NotificationsController < AdminController
   def preview
     renderer = CustomMarkdownRenderer.new
     markdown_parser = Redcarpet::Markdown.new(renderer)
-    @html = markdown_parser.render(params[:text])
+    @markdown_message = markdown_parser.render(params[:message])
 
-    render json: { html: @html }
+    render json: { summary: params[:summary], message: @markdown_message }
   end
 
   def unpublish
@@ -46,6 +47,6 @@ class Admin::NotificationsController < AdminController
   private
 
   def notification_params
-    params.require(:notification).permit(:notification_message)
+    params.require(:notification).permit(:summary, :notification_message)
   end
 end

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -10,12 +10,13 @@ class Admin::NotificationsController < AdminController
     @notification = Notification.new
   end
 
+  # rubocop:disable Metrics/AbcSize
   def create
     renderer = CustomMarkdownRenderer.new
     markdown_parser = Redcarpet::Markdown.new(renderer)
     html = markdown_parser.render(notification_params[:notification_message])
-    @notification = Notification.new(summary: notification_params[:summary], notification_message: html, user: current_user['email'], published: true,
-                                     published_at: Time.zone.now)
+    @notification = Notification.new(summary: notification_params[:summary], notification_message: html,
+                                     user: current_user['email'], published: true, published_at: Time.zone.now)
     Notification.transaction do
       if @notification.save
         flash[:success] = 'Notification created successfully.'
@@ -26,6 +27,7 @@ class Admin::NotificationsController < AdminController
       end
     end
   end
+  # rubocop:enable Metrics/AbcSize
 
   def preview
     renderer = CustomMarkdownRenderer.new

--- a/app/models/notification.rb
+++ b/app/models/notification.rb
@@ -1,5 +1,5 @@
 class Notification < ApplicationRecord
-  validates :notification_message, presence: true
+  validates :summary, :notification_message, presence: true
 
   before_save :ensure_single_published_notification
 

--- a/app/serializable/serializable_notification.rb
+++ b/app/serializable/serializable_notification.rb
@@ -1,5 +1,5 @@
 class SerializableNotification < JSONAPI::Serializable::Resource
   type 'notifications'
 
-  attribute :notification_message
+  attributes :summary, :notification_message
 end

--- a/app/views/admin/notifications/index.html.haml
+++ b/app/views/admin/notifications/index.html.haml
@@ -15,11 +15,11 @@
     - if @published_notification.present?
       %h2.govuk-heading-m
         Current notification
-      .govuk-notification-banner{"aria-labelledby" => "govuk-notification-banner-title", "data-module" => "govuk-notification-banner", role: "region", class: 'govuk-!-margin-bottom-3'}
-        .govuk-notification-banner__header
-          %h2#govuk-notification-banner-title.govuk-notification-banner__title
-            Important
-        .govuk-notification-banner__content
+      %details.govuk-details{ open: true }
+        %summary.govuk-details__summary.govuk-heading-m
+          %span.govuk-details__summary-text
+            = @published_notification.summary.html_safe
+        .govuk-details__text
           = @published_notification.notification_message.html_safe
       = button_to 'Unpublish', unpublish_admin_notification_path(@published_notification), method: :post, class: 'govuk-button'
     - else

--- a/app/views/admin/notifications/new.html.haml
+++ b/app/views/admin/notifications/new.html.haml
@@ -5,14 +5,14 @@
         %legend.govuk-fieldset__legend.govuk-fieldset__legend--xl
           %h1.govuk-fieldset__heading
             Create a new notification
-            
-        = form.input :notification_message, hide_optional: true, wrapper: :govuk_textarea_wrapper
+
+        = form.input :summary, hide_optional: true
+        = form.input :notification_message, label: 'Notification message', hide_optional: true, wrapper: :govuk_textarea_wrapper
         %button#markdown-preview-btn{type: "button", class: 'govuk-button'} Preview
         = form.button :submit, value: 'Publish Notification', data: { disable_with: "Publish Notification" }
 
-    .govuk-notification-banner{"aria-labelledby" => "govuk-notification-banner-title", "data-module" => "govuk-notification-banner", role: "region"}
-      .govuk-notification-banner__header
-        %h2#govuk-notification-banner-title.govuk-notification-banner__title
-          Important
-      #markdown-preview.govuk-notification-banner__content
-
+    #preview-container.govuk-visually-hidden
+      %details.govuk-details
+        %summary.govuk-details__summary.govuk-heading-m
+          %span#summary-preview.govuk-details__summary-text
+        #markdown-preview.govuk-details__text

--- a/config/initializers/simple_form.rb
+++ b/config/initializers/simple_form.rb
@@ -14,14 +14,10 @@ SimpleForm.setup do |config|
     b.use :input, class: 'govuk-input', error_class: 'govuk-input--error'
   end
 
-  config.wrappers :govuk_textarea_wrapper, tag: 'div', class: 'govuk-textarea-wrapper',
-error_class: 'govuk-error' do |b|
-    b.use :html5
-    b.use :placeholder
-    b.optional :maxlength
-    b.optional :minlength
-    b.use :error, wrap_with: { tag: 'span', class: 'govuk-error-message' }
-    b.use :input, class: 'govuk-textarea', error_class: 'govuk-input--error'
+  config.wrappers :govuk_textarea_wrapper, parent: :default do |b|
+    b.use :label, class: 'govuk-label'
+    b.use :full_error, wrap_with: { tag: 'span', class: 'govuk-error-message' }
+    b.use :input, class: 'govuk-textarea', input_html: { rows: 5 }
   end
 
   # The default wrapper to be used by the FormBuilder.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -23,6 +23,8 @@ en:
               blank: 'Salesforce ID cannot be blank'
         notification:
           attributes:
+            summary:
+              blank: 'Summary cannot be blank'
             notification_message:
               blank: 'Notification message cannot be blank'
   errors:

--- a/db/migrate/20240919110143_add_summary_to_notifications.rb
+++ b/db/migrate/20240919110143_add_summary_to_notifications.rb
@@ -1,0 +1,5 @@
+class AddSummaryToNotifications < ActiveRecord::Migration[7.1]
+  def change
+    add_column :notifications, :summary, :text, null: false, default: 'Important'
+  end
+end

--- a/db/migrate/20240924105747_remove_default_from_summary_in_notifications.rb
+++ b/db/migrate/20240924105747_remove_default_from_summary_in_notifications.rb
@@ -1,0 +1,5 @@
+class RemoveDefaultFromSummaryInNotifications < ActiveRecord::Migration[7.1]
+  def change
+    change_column_default :notifications, :summary, nil
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_05_30_103925) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_24_105747) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pgcrypto"
@@ -162,6 +162,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_05_30_103925) do
     t.datetime "published_at"
     t.datetime "unpublished_at"
     t.string "user"
+    t.text "summary", null: false
     t.index ["published"], name: "index_notifications_on_published"
   end
 

--- a/lib/custom_markdown_renderer.rb
+++ b/lib/custom_markdown_renderer.rb
@@ -2,10 +2,10 @@ require 'redcarpet'
 
 class CustomMarkdownRenderer < Redcarpet::Render::HTML
   def link(link, title, content)
-    "<a href=\"#{link}\" title=\"#{title}\" class=\"govuk-notification-banner__link\" target=\"_blank\">#{content}</a>"
+    "<a href=\"#{link}\" title=\"#{title}\" class=\"govuk-link\" target=\"_blank\">#{content}</a>"
   end
 
   def paragraph(content)
-    "<p class=\"govuk-notification-banner__heading\">#{content}</p>"
+    "<p class=\"govuk-body\">#{content}</p>"
   end
 end

--- a/spec/factories/notifications.rb
+++ b/spec/factories/notifications.rb
@@ -1,5 +1,6 @@
 FactoryBot.define do
   factory :notification do
+    summary { 'Hello there' }
     notification_message { 'Wear sunscreen' }
     published { false }
     published_at { Time.zone.now }

--- a/spec/features/admin_can_manage_notifications_spec.rb
+++ b/spec/features/admin_can_manage_notifications_spec.rb
@@ -13,23 +13,27 @@ RSpec.feature 'Managing notifications' do
 
     expect(page).to have_text('Create a new notification')
 
-    fill_in 'notification_notification_message', with: 'Urgent update!'
+    fill_in 'notification_summary', with: 'Urgent update!'
+    fill_in 'notification_notification_message', with: 'Oh never mind.'
     click_button 'Publish Notification'
 
     expect(page).to have_text('Notification created successfully.')
     expect(page).to have_content('Urgent update!')
+    expect(page).to have_content('Oh never mind.')
   end
 
-  scenario 'notification message is empty' do
+  scenario 'summary or notification message is empty' do
     visit new_admin_notification_path
     click_button 'Publish Notification'
 
+    expect(page).to have_text('Summary cannot be blank')
     expect(page).to have_text('Notification message cannot be blank')
   end
 
   scenario 'unpublish current notification' do
     visit new_admin_notification_path
-    fill_in 'notification_notification_message', with: 'Urgent update!'
+    fill_in 'notification_summary', with: 'Urgent update!'
+    fill_in 'notification_notification_message', with: 'Oh never mind.'
     click_button 'Publish Notification'
 
     expect(page).to have_text('Current notification')

--- a/spec/models/notification_spec.rb
+++ b/spec/models/notification_spec.rb
@@ -2,7 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Notification, type: :model do
   describe 'validations' do
-    subject { create(:notification, published: true, notification_message: 'test') }
+    subject { create(:notification, published: true) }
+    it { is_expected.to validate_presence_of(:summary) }
     it { is_expected.to validate_presence_of(:notification_message) }
   end
 

--- a/spec/requests/admin/notifications_spec.rb
+++ b/spec/requests/admin/notifications_spec.rb
@@ -12,14 +12,14 @@ RSpec.describe 'Admin Notifications', type: :request do
   describe '#preview' do
     it 'renders the Markdown content as HTML' do
       markdown_content = '**Bold Text**'
-      expected_html = '<p class="govuk-notification-banner__heading"><strong>Bold Text</strong></p>'
+      expected_html = '<p class="govuk-body"><strong>Bold Text</strong></p>'
 
-      post admin_notifications_preview_path, params: { text: markdown_content }
+      post admin_notifications_preview_path, params: { summary: 'summary', message: markdown_content }
 
       expect(response).to be_successful
       expect(response.header['Content-Type']).to include 'application/json'
       json_response = JSON.parse(response.body)
-      expect(json_response['html']).to eq(expected_html)
+      expect(json_response['message']).to eq(expected_html)
     end
   end
 

--- a/spec/requests/v1/notifications_spec.rb
+++ b/spec/requests/v1/notifications_spec.rb
@@ -26,7 +26,8 @@ RSpec.describe '/v1' do
     end
 
     it 'returns the details of the current published notification' do
-      FactoryBot.create(:notification, published: true, summary: 'Testy McTestface', notification_message: 'The answer is 42')
+      FactoryBot.create(:notification, published: true, summary: 'Testy McTestface',
+notification_message: 'The answer is 42')
 
       get '/v1/notifications', headers: { 'X-Auth-Id' => JWT.encode(user.auth_id, 'test') }
 

--- a/spec/requests/v1/notifications_spec.rb
+++ b/spec/requests/v1/notifications_spec.rb
@@ -26,11 +26,13 @@ RSpec.describe '/v1' do
     end
 
     it 'returns the details of the current published notification' do
-      FactoryBot.create(:notification, published: true, notification_message: 'The answer is 42')
+      FactoryBot.create(:notification, published: true, summary: 'Testy McTestface', notification_message: 'The answer is 42')
 
       get '/v1/notifications', headers: { 'X-Auth-Id' => JWT.encode(user.auth_id, 'test') }
 
       expect(response).to be_successful
+      expect(json['data'])
+        .to have_attribute(:summary)
       expect(json['data'])
         .to have_attribute(:notification_message)
     end


### PR DESCRIPTION
## Description
Update notification banner to use detail component instead
https://crowncommercialservice.atlassian.net/browse/NRMI-28

## Why was the change made?
Reduce the annoying aspects of current functionality to encourage the use of it.

## Are there any dependencies required for this change?
Migrations must be run in console on running instance in each environment. Changes to Frontend to be deployed simultaneously.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Unit, feature and manual testing
