### PR TITLE
NRMI-10: past notifications log

### DIFF
--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -3,11 +3,15 @@ require 'custom_markdown_renderer'
 class Admin::NotificationsController < AdminController
   def index
     @published_notification = Notification.published.first
-    @notifications = Notification.order(created_at: :desc).all
+    @notifications = Notification.order(published_at: :desc).all
   end
 
   def new
     @notification = Notification.new
+  end
+
+  def show
+    @notification = Notification.find(params[:id])
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/views/admin/notifications/index.html.haml
+++ b/app/views/admin/notifications/index.html.haml
@@ -26,3 +26,18 @@
       %h2.govuk-heading-m
         No notification currently published    
 
+.govuk-grid-row
+  .govuk-grid-column-full
+    - if @notifications.present?
+      %table.govuk-table{:class => 'govuk-!-margin-top-7'}
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header Header
+            %th.govuk-table__header Published
+            %th.govuk-table__header Unpublished
+        %tbody.govuk-table__body
+          - @notifications.each do |notification|
+            %tr.govuk-table__row
+              %td.govuk-table__cell= link_to notification.summary, admin_notification_path(notification.id)
+              %td.govuk-table__cell= notification.published_at
+              %td.govuk-table__cell= notification.unpublished_at

--- a/app/views/admin/notifications/show.html.haml
+++ b/app/views/admin/notifications/show.html.haml
@@ -1,0 +1,10 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = link_to 'Back', admin_notifications_path, { class: 'govuk-back-link govuk-!-margin-bottom-5', title: 'Back to notifications' }
+
+    %details#notification.govuk-details{ open: true }
+      %summary.govuk-details__summary.govuk-heading-m
+        %span.govuk-details__summary-text
+          = @notification.summary.html_safe
+      .govuk-details__text
+        = @notification.notification_message.html_safe

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,7 +152,7 @@ Rails.application.routes.draw do
 
     resources :unfinished_tasks, only: %i[index]
 
-    resources :notifications, only: %i[index new create] do
+    resources :notifications, only: %i[index new show create] do
       member do
         post :unpublish
       end

--- a/spec/features/admin_can_manage_notifications_spec.rb
+++ b/spec/features/admin_can_manage_notifications_spec.rb
@@ -45,4 +45,24 @@ RSpec.feature 'Managing notifications' do
     expect(page).to have_text('Notification was successfully unpublished.')
     expect(page).to have_text('No notification currently published')
   end
+
+  scenario 'view past notifications' do
+    number = 0
+    2.times do
+      visit new_admin_notification_path
+      fill_in 'notification_summary', with: "Testy McTestface #{number += 1}"
+      fill_in 'notification_notification_message', with: "I'm number #{number}"
+      click_button 'Publish Notification'
+    end
+    
+    visit admin_notifications_path
+
+    expect(page).to have_text('Testy McTestface 1')
+    expect(page).to have_text('Testy McTestface 2')
+
+    click_link 'Testy McTestface 1'
+
+    expect(page).to have_text('Testy McTestface 1')
+    expect(page).to have_text('I\'m number 1')
+  end
 end

--- a/spec/features/admin_can_manage_notifications_spec.rb
+++ b/spec/features/admin_can_manage_notifications_spec.rb
@@ -54,7 +54,7 @@ RSpec.feature 'Managing notifications' do
       fill_in 'notification_notification_message', with: "I'm number #{number}"
       click_button 'Publish Notification'
     end
-    
+
     visit admin_notifications_path
 
     expect(page).to have_text('Testy McTestface 1')


### PR DESCRIPTION
## Description
Added past notifications log
https://crowncommercialservice.atlassian.net/browse/NRMI-10

## Why was the change made?
Allow the user to see past messages.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual testing
