### PR TITLE
Change `docker-compose` to `docker compose` due to changes in Docker Compose v2 which deprecated `docker-compose`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,10 +30,10 @@ The most common command used to start all containers. It does database set up if
 $ bin/dstart
 ```
 
-If you'd like to see all logs, like `Sidekiq` or `Redis` you can use the conventional docker-compose command - you will lose the ability to use `pry`:
+If you'd like to see all logs, like `Sidekiq` or `Redis` you can use the conventional `docker compose` command - you will lose the ability to use `pry`:
 
 ```bash
-$ docker-compose --env-file docker-compose.env up --build
+$ docker compose --env-file docker-compose.env up --build
 ```
 
 If you'd like to shut all containers down, and remove database information persisted in `docker volumes` you can run the following command which rebuilds everything from scratch:
@@ -78,7 +78,7 @@ $ bin/dtest-server down
 When making changes to the Gemfile we should use Docker too in order to ensure we use a consistent version of Bundler:
 
 ```bash
-$ docker-compose run --rm web bundle
+$ docker compose run --rm web bundle
 ```
 
 The Bundler version in the Gemfile.lock should remain unchanged unless part of a deliberate update.

--- a/bin/dclean-slate
+++ b/bin/dclean-slate
@@ -4,7 +4,7 @@
 # This process takes much more time to rebuild from but aims to guarantee a fresh state.
 
 echo "Removing all traces of the test server…"
-docker-compose --file=docker-compose.test.yml down --rmi=all -v --remove-orphans
+docker compose --file=docker-compose.test.yml down --rmi=all -v --remove-orphans
 
 echo "Removing all traces of the web server…"
-docker-compose down -v --rmi=all --remove-orphans
+docker compose down -v --rmi=all --remove-orphans

--- a/bin/drails
+++ b/bin/drails
@@ -1,3 +1,3 @@
 #!/bin/sh
 set +e
-docker-compose run --rm web bin/rails "$@"
+docker compose run --rm web bin/rails "$@"

--- a/bin/drake
+++ b/bin/drake
@@ -1,3 +1,3 @@
 #!/bin/sh
 set +e
-docker-compose run --rm web bundle exec rake "$@"
+docker compose run --rm web bundle exec rake "$@"

--- a/bin/drebuild
+++ b/bin/drebuild
@@ -4,14 +4,14 @@ echo "Remove all unused images before we build new ones…"
 docker image prune -f
 
 echo "Rebuilding the test server…"
-docker-compose --file=docker-compose.test.yml down -v --remove-orphans
-docker-compose --file=docker-compose.test.yml --env-file docker-compose.env build
+docker compose --file=docker-compose.test.yml down -v --remove-orphans
+docker compose --file=docker-compose.test.yml --env-file docker-compose.env build
 bin/dtest-server
 echo "Rebuilt and started the testing server for DSS."
 
 echo "Rebuilding the web server…"
-docker-compose down -v --remove-orphans
-docker-compose --env-file docker-compose.env build
-docker-compose run --rm web rake db:seed
+docker compose down -v --remove-orphans
+docker compose --env-file docker-compose.env build
+docker compose run --rm web rake db:seed
 echo "Rebuilt and starting the web server for DSS."
 bin/dstart

--- a/bin/dstart
+++ b/bin/dstart
@@ -10,13 +10,13 @@ function cleanup {
 
   # ignore errors
   set +e
-  docker-compose down
+  docker compose down
 
   exit $code
 }
 
 trap cleanup EXIT
 
-docker-compose --env-file docker-compose.env up -d --build
+docker compose --env-file docker-compose.env up -d --build
 
 docker attach data-submission-service-api_web

--- a/bin/dtest-server
+++ b/bin/dtest-server
@@ -3,25 +3,25 @@ set -e
 
 start_test_server()
 {
-  docker-compose --file docker-compose.test.yml --env-file docker-compose.env build
-  docker-compose --file docker-compose.test.yml --env-file docker-compose.env up -d db-test
-  docker-compose --file docker-compose.test.yml --env-file docker-compose.env up -d test
+  docker compose --file docker-compose.test.yml --env-file docker-compose.env build
+  docker compose --file docker-compose.test.yml --env-file docker-compose.env up -d db-test
+  docker compose --file docker-compose.test.yml --env-file docker-compose.env up -d test
 }
 
 
 if [[ $# -eq 0 ]]
 then
-  docker-compose --file docker-compose.test.yml down
+  docker compose --file docker-compose.test.yml down
   start_test_server
 fi
 
 if [[ $1 == "up" ]]
 then
-  docker-compose --file docker-compose.test.yml down
+  docker compose --file docker-compose.test.yml down
   start_test_server
 fi
 
 if [[ $1 == "down" ]]
 then
-  docker-compose --file docker-compose.test.yml down
+  docker compose --file docker-compose.test.yml down
 fi

--- a/bin/dtests
+++ b/bin/dtests
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-docker-compose --file docker-compose.test.yml build
-docker-compose --file docker-compose.test.yml up -d db-test
-docker-compose --file docker-compose.test.yml run test rake
-docker-compose --file docker-compose.test.yml down
+docker compose --file docker-compose.test.yml build
+docker compose --file docker-compose.test.yml up -d db-test
+docker compose --file docker-compose.test.yml run test rake
+docker compose --file docker-compose.test.yml down

--- a/docs/get-prod-db-backup.md
+++ b/docs/get-prod-db-backup.md
@@ -40,7 +40,7 @@ Finally move the file into the `backups` directory ready to be restored.
 
 Launch a temporary instance of the `web` service, and get a shell on it.
 
-    docker-compose run --rm web bash
+    docker compose run --rm web bash
 
 On this container, install the Postgres client command-line tools, and then run
 a task to load the database backup into the development database.


### PR DESCRIPTION

## Description
Change `docker-compose` to `docker compose` due to changes in Docker Compose v2 which deprecated `docker-compose`

See https://crowncommercialservice.atlassian.net/browse/NRMI-77?focusedCommentId=102443

## What type of change is it?
Please delete options that are not relevant.

 [ ] Bug fix

 [ ] New feature 

 [ ] Breaking change 

 [x] This change requires a documentation update

## How was the change tested?
I tried the start up script to make sure it still worked