### PR TITLE
Release/161

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [release-160] - 2024-10-28
+
+- NRMI-10: Added past notifications log
+
 ## [release-159] - 2024-10-07
 
 - NRMI-28: Change notification banner to details component
@@ -1063,6 +1067,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-160]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-159...release-160
 [release-159]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-158...release-159
 [release-158]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-157...release-158
 [release-157]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-156...release-157

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [release-159] - 2024-10-07
+
+- NRMI-28: Change notification banner to details component
+- NRMI-27: Resize admin notification message text box
+
 ## [release-158] - 2024-08-19
 
 - RMI-691: get framework lots 
@@ -1058,6 +1063,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-159]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-158...release-159
 [release-158]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-157...release-158
 [release-157]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-156...release-157
 [release-156]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-155...release-156

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log
 
+## [release-161] - 2024-11-25
+
+- NRMI-76: Make name mandatory when adding a new user
+- NRMI-9: Add edit notification functionality
+
 ## [release-160] - 2024-10-28
 
 - NRMI-10: Added past notifications log
@@ -1067,6 +1072,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-161]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-160...release-161
 [release-160]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-159...release-160
 [release-159]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-158...release-159
 [release-158]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-157...release-158

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -3,11 +3,15 @@ require 'custom_markdown_renderer'
 class Admin::NotificationsController < AdminController
   def index
     @published_notification = Notification.published.first
-    @notifications = Notification.order(created_at: :desc).all
+    @notifications = Notification.order(published_at: :desc).all
   end
 
   def new
     @notification = Notification.new
+  end
+
+  def show
+    @notification = Notification.find(params[:id])
   end
 
   # rubocop:disable Metrics/AbcSize

--- a/app/controllers/admin/notifications_controller.rb
+++ b/app/controllers/admin/notifications_controller.rb
@@ -2,24 +2,28 @@ require 'custom_markdown_renderer'
 
 class Admin::NotificationsController < AdminController
   def index
+    markdown_parser = Redcarpet::Markdown.new(CustomMarkdownRenderer)
     @published_notification = Notification.published.first
+    if @published_notification
+      @published_notification_message = markdown_parser.render(@published_notification[:notification_message])
+    end
     @notifications = Notification.order(published_at: :desc).all
   end
 
   def new
     @notification = Notification.new
+    @published_notification = Notification.find(params[:published_notification]) if params[:published_notification]
   end
 
   def show
+    markdown_parser = Redcarpet::Markdown.new(CustomMarkdownRenderer)
     @notification = Notification.find(params[:id])
+    @notification_message = markdown_parser.render(@notification[:notification_message])
   end
 
-  # rubocop:disable Metrics/AbcSize
   def create
-    renderer = CustomMarkdownRenderer.new
-    markdown_parser = Redcarpet::Markdown.new(renderer)
-    html = markdown_parser.render(notification_params[:notification_message])
-    @notification = Notification.new(summary: notification_params[:summary], notification_message: html,
+    @notification = Notification.new(summary: notification_params[:summary],
+                                     notification_message: notification_params[:notification_message],
                                      user: current_user['email'], published: true, published_at: Time.zone.now)
     Notification.transaction do
       if @notification.save
@@ -31,11 +35,9 @@ class Admin::NotificationsController < AdminController
       end
     end
   end
-  # rubocop:enable Metrics/AbcSize
 
   def preview
-    renderer = CustomMarkdownRenderer.new
-    markdown_parser = Redcarpet::Markdown.new(renderer)
+    markdown_parser = Redcarpet::Markdown.new(CustomMarkdownRenderer)
     @markdown_message = markdown_parser.render(params[:message])
 
     render json: { summary: params[:summary], message: @markdown_message }

--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -26,7 +26,6 @@ class Admin::UsersController < AdminController
   end
 
   def create
-    return redirect_to new_admin_user_path, alert: 'You must provide an email address.' if params[:user][:email].blank?
     return redirect_to new_admin_user_path, alert: 'Email address already exists.' if existing_email?
 
     supplier_sf_ids = split_sf_ids(params[:supplier_salesforce_ids])

--- a/app/controllers/v1/notifications_controller.rb
+++ b/app/controllers/v1/notifications_controller.rb
@@ -1,6 +1,10 @@
+require 'custom_markdown_renderer'
+
 class V1::NotificationsController < ApiController
   def index
+    markdown_parser = Redcarpet::Markdown.new(CustomMarkdownRenderer)
     notifications = Notification.published.first
+    notifications[:notification_message] = markdown_parser.render(notifications[:notification_message]) if notifications
 
     render jsonapi: notifications
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ApplicationRecord
   has_many :agreements, through: :suppliers
   has_many :tasks, through: :suppliers
   has_many :customer_effort_scores, dependent: :nullify
+  validates :name, presence: true
   validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }
 
   scope :active, -> { where.not(auth_id: nil) }

--- a/app/services/create_user.rb
+++ b/app/services/create_user.rb
@@ -9,7 +9,7 @@ class CreateUser
     result = Result.new(true)
 
     User.transaction do
-      user.save
+      user.save!
       begin
         CreateUserInAuth0.new(user: user).call
       rescue Auth0::Exception

--- a/app/views/admin/notifications/index.html.haml
+++ b/app/views/admin/notifications/index.html.haml
@@ -20,8 +20,9 @@
           %span.govuk-details__summary-text
             = @published_notification.summary.html_safe
         .govuk-details__text
-          = @published_notification.notification_message.html_safe
-      = button_to 'Unpublish', unpublish_admin_notification_path(@published_notification), method: :post, class: 'govuk-button'
+          = @published_notification_message.html_safe
+      = link_to 'Unpublish', unpublish_admin_notification_path(@published_notification), method: :post, class: 'govuk-button'
+      = link_to 'Edit', new_admin_notification_path(published_notification: @published_notification), class: 'govuk-button'
     - else
       %h2.govuk-heading-m
         No notification currently published    

--- a/app/views/admin/notifications/index.html.haml
+++ b/app/views/admin/notifications/index.html.haml
@@ -26,3 +26,18 @@
       %h2.govuk-heading-m
         No notification currently published    
 
+.govuk-grid-row
+  .govuk-grid-column-full
+    - if @notifications.present?
+      %table.govuk-table{:class => 'govuk-!-margin-top-7'}
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header Header
+            %th.govuk-table__header Published
+            %th.govuk-table__header Unpublished
+        %tbody.govuk-table__body
+          - @notifications.each do |notification|
+            %tr.govuk-table__row
+              %td.govuk-table__cell= link_to notification.summary, admin_notification_path(notification.id)
+              %td.govuk-table__cell= notification.published_at
+              %td.govuk-table__cell= notification.unpublished_at

--- a/app/views/admin/notifications/new.html.haml
+++ b/app/views/admin/notifications/new.html.haml
@@ -6,8 +6,8 @@
           %h1.govuk-fieldset__heading
             Create a new notification
 
-        = form.input :summary, hide_optional: true
-        = form.input :notification_message, label: 'Notification message', hide_optional: true, wrapper: :govuk_textarea_wrapper, input_html: { rows: '10' }
+        = form.input :summary, hide_optional: true, input_html: { value: @published_notification&.summary }
+        = form.input :notification_message, label: 'Notification message', hide_optional: true, wrapper: :govuk_textarea_wrapper, input_html: { rows: '10', value: @published_notification&.notification_message }
         %button#markdown-preview-btn{type: "button", class: 'govuk-button'} Preview
         = form.button :submit, value: 'Publish Notification', data: { disable_with: "Publish Notification" }
 

--- a/app/views/admin/notifications/new.html.haml
+++ b/app/views/admin/notifications/new.html.haml
@@ -7,7 +7,7 @@
             Create a new notification
 
         = form.input :summary, hide_optional: true
-        = form.input :notification_message, label: 'Notification message', hide_optional: true, wrapper: :govuk_textarea_wrapper
+        = form.input :notification_message, label: 'Notification message', hide_optional: true, wrapper: :govuk_textarea_wrapper, input_html: { rows: '10' }
         %button#markdown-preview-btn{type: "button", class: 'govuk-button'} Preview
         = form.button :submit, value: 'Publish Notification', data: { disable_with: "Publish Notification" }
 

--- a/app/views/admin/notifications/show.html.haml
+++ b/app/views/admin/notifications/show.html.haml
@@ -7,4 +7,4 @@
         %span.govuk-details__summary-text
           = @notification.summary.html_safe
       .govuk-details__text
-        = @notification.notification_message.html_safe
+        = @notification_message.html_safe

--- a/app/views/admin/notifications/show.html.haml
+++ b/app/views/admin/notifications/show.html.haml
@@ -1,0 +1,10 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = link_to 'Back', admin_notifications_path, { class: 'govuk-back-link govuk-!-margin-bottom-5', title: 'Back to notifications' }
+
+    %details#notification.govuk-details{ open: true }
+      %summary.govuk-details__summary.govuk-heading-m
+        %span.govuk-details__summary-text
+          = @notification.summary.html_safe
+      .govuk-details__text
+        = @notification.notification_message.html_safe

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -12,8 +12,10 @@ en:
       models:
         user:
           attributes:
+            name:
+              blank: 'You must provide a name.'
             email:
-              blank: 'Enter an email address'
+              blank: 'You must provide an email address.'
               invalid: 'Enter an email address in the correct format, like name@example.com'
         supplier:
           attributes:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,7 +152,7 @@ Rails.application.routes.draw do
 
     resources :unfinished_tasks, only: %i[index]
 
-    resources :notifications, only: %i[index new create] do
+    resources :notifications, only: %i[index new show create] do
       member do
         post :unpublish
       end

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -40,6 +40,18 @@ RSpec.feature 'Adding a user' do
     expect(page).to have_content(supplier_2.name)
   end
 
+  context 'when no name is provided' do
+    scenario 'it fails and prompts you to provide a name' do
+      click_on 'Users'
+      click_on 'Add a new user'
+      fill_in 'Email address', with: email
+      fill_in 'salesforce-ids', with: supplier_2.salesforce_id
+      click_button 'Add new user'
+
+      expect(page).to have_content('You must provide a name.')
+    end
+  end
+
   context 'when no email provided' do
     scenario 'it fails and prompts you to provide an email address' do
       click_on 'Users'

--- a/spec/features/admin_can_manage_notifications_spec.rb
+++ b/spec/features/admin_can_manage_notifications_spec.rb
@@ -39,11 +39,35 @@ RSpec.feature 'Managing notifications' do
     expect(page).to have_text('Current notification')
     expect(page).not_to have_text('No notification currently published')
 
-    click_button 'Unpublish'
+    click_link 'Unpublish'
 
     expect(page).not_to have_text('Current notification')
     expect(page).to have_text('Notification was successfully unpublished.')
     expect(page).to have_text('No notification currently published')
+  end
+
+  scenario 'edit current notification but keep a record' do
+    visit new_admin_notification_path
+    fill_in 'notification_summary', with: 'Just FYI'
+    fill_in 'notification_notification_message', with: 'You should wear sunscreen'
+    click_button 'Publish Notification'
+
+    expect(page).to have_text('Current notification')
+    expect(page).to have_text('Edit')
+
+    click_link 'Edit'
+
+    expect(page).to have_text('Just FYI')
+    expect(page).to have_text('sunscreen')
+
+    fill_in 'notification_summary', with: 'Just FYI2'
+    fill_in 'notification_notification_message', with: 'Drink water'
+    click_button 'Publish Notification'
+
+    expect(page).to have_text('Notification created successfully.')
+    expect(page).to have_text('Just FYI')
+    expect(page).to have_text('Just FYI 2')
+    expect(page).to have_text('Drink water')
   end
 
   scenario 'view past notifications' do

--- a/spec/features/admin_can_manage_notifications_spec.rb
+++ b/spec/features/admin_can_manage_notifications_spec.rb
@@ -45,4 +45,24 @@ RSpec.feature 'Managing notifications' do
     expect(page).to have_text('Notification was successfully unpublished.')
     expect(page).to have_text('No notification currently published')
   end
+
+  scenario 'view past notifications' do
+    number = 0
+    2.times do
+      visit new_admin_notification_path
+      fill_in 'notification_summary', with: "Testy McTestface #{number += 1}"
+      fill_in 'notification_notification_message', with: "I'm number #{number}"
+      click_button 'Publish Notification'
+    end
+
+    visit admin_notifications_path
+
+    expect(page).to have_text('Testy McTestface 1')
+    expect(page).to have_text('Testy McTestface 2')
+
+    click_link 'Testy McTestface 1'
+
+    expect(page).to have_text('Testy McTestface 1')
+    expect(page).to have_text('I\'m number 1')
+  end
 end


### PR DESCRIPTION
## Description
- [Add edit notification functionality](https://crowncommercialservice.atlassian.net/browse/NRMI-9)
- [Make name mandatory in adding new user](https://crowncommercialservice.atlassian.net/browse/NRMI-76)

## Why was the change made?
Reduce the time it takes the user to change an existing message. Name field was incorrectly labelled as optional

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

 [X] New feature 

## How was the change tested?
Unit, feature and manual tests
