### PR TITLE
NRMI-84

### DIFF
--- a/app/models/framework/definition/ast/creator.rb
+++ b/app/models/framework/definition/ast/creator.rb
@@ -34,6 +34,9 @@ class Framework
         rule(optional: simple(:optional), type_def: subtree(:type), field: simple(:field), from: subtree(:from)) do
           { kind: :additional, optional: true, type: type, field: field.to_s, from: from }
         end
+        rule(optional: simple(:optional), type_def: subtree(:type), field: simple(:field), from: subtree(:from), depends_on: subtree(:depends_on)) do
+          { kind: :additional, optional: true, type: type, field: field.to_s, from: from, depends_on: depends_on }
+        end
 
         # Additional field rule
         rule(type_def: subtree(:type), field: simple(:field), from: subtree(:from)) do
@@ -50,6 +53,9 @@ class Framework
 
         rule(optional: simple(:optional), type_def: subtree(:type), from: simple(:from)) do
           { kind: :unknown, optional: true, type: type, from: from }
+        end
+        rule(optional: simple(:optional), type_def: subtree(:type), from: simple(:from), depends_on: subtree(:depends_on)) do
+          { kind: :unknown, optional: true, type: type, from: from, depends_on: depends_on }
         end
 
         # Lookups

--- a/app/models/framework/definition/ast/field/options.rb
+++ b/app/models/framework/definition/ast/field/options.rb
@@ -29,7 +29,7 @@ class Framework
           def add_inclusion_validators(lookup_values)
             options[:case_insensitive_inclusion] = { in: lookup_values } if lookup_values&.any?
             if field.dependent_field_inclusion?
-              options[:dependent_field_inclusion] = { parents: field.dependent_fields, in: field.dependent_field_inclusion_values }
+              options[:dependent_field_inclusion] = { parents: field.dependent_fields, in: field.dependent_field_inclusion_values, optional: field.optional? }
             end
           end
 

--- a/app/validators/dependent_field_inclusion_validator.rb
+++ b/app/validators/dependent_field_inclusion_validator.rb
@@ -3,6 +3,8 @@ class DependentFieldInclusionValidator < ActiveModel::EachValidator
     parent_field_values = get_parent_field_values(record)
     parent_field_value_lookup = parent_field_values.map { |v| v&.downcase }
 
+    return if optional && value.nil?
+
     valid_values = get_valid_values(parent_field_value_lookup)
     return if valid_values.include?(value&.downcase)
 
@@ -17,6 +19,10 @@ class DependentFieldInclusionValidator < ActiveModel::EachValidator
   end
 
   private
+
+  def optional
+    options[:optional]
+  end
 
   def parent_field_names
     options[:parents]

--- a/spec/models/framework/definition/generator_spec.rb
+++ b/spec/models/framework/definition/generator_spec.rb
@@ -357,7 +357,7 @@ RSpec.describe Framework::Definition::Generator do
 
         it {
           is_expected.to have_field('Vehicle Segment')
-            .validated_by(dependent_field_inclusion: { parents: ['Lot Number'], in: mappings })
+            .validated_by(dependent_field_inclusion: { parents: ['Lot Number'], in: mappings, optional: nil })
         }
 
         it {
@@ -715,7 +715,7 @@ RSpec.describe Framework::Definition::Generator do
               parents: ['Service Type'],
               in: {
                 ['core'] => %w[Hi], ['non-core'] => %w[There], ['mixture'] => %w[Hi There]
-              }
+              }, optional: nil
             }
           )
         }
@@ -728,7 +728,7 @@ RSpec.describe Framework::Definition::Generator do
                 ['core', '1'] => ['Hi'],
                 ['mixture', '2'] => ['There'],
                 ['non-core', Framework::Definition::AST::Any] => ['Hi', 'There']
-              }
+              }, optional: nil
             }
           )
         }


### PR DESCRIPTION
## Description
- [FDL optional fields are not optional when `depends_on`](https://crowncommercialservice.atlassian.net/browse/NRMI-84)

## Why was the change made?
To be able to have an optional field with data validation dependant on another field.
Prevent user queries about improper data validation / error messages.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
