### PR TITLE
NRMI-79: Link supplier on unfinished tasks

### DIFF
--- a/app/views/admin/unfinished_tasks/_tasks_table.html.haml
+++ b/app/views/admin/unfinished_tasks/_tasks_table.html.haml
@@ -11,7 +11,7 @@
     - @tasks.each do |task|
       %tr.govuk-table__row
         %td.govuk-table__cell
-          = task.supplier.name
+          = link_to task.supplier.name, admin_supplier_path(task.supplier)
         %td.govuk-table__cell
           = task.framework.short_name
           %br/

--- a/spec/features/admin_can_list_unfinished_tasks_spec.rb
+++ b/spec/features/admin_can_list_unfinished_tasks_spec.rb
@@ -39,4 +39,12 @@ aasm_state: state) do |submission|
     expect(page.response_headers['Content-Disposition']).to include 'RM0000 Test Supplier Ltd %28February 2018%29.xlsx'
     expect(page.body).to include File.open(Rails.root.join('spec', 'fixtures', 'test.xlsx'), 'r:ASCII-8BIT', &:read)
   end
+
+  scenario 'admin can click through to supplier page' do
+    visit admin_unfinished_tasks_path
+
+    click_link('Test Supplier Ltd', match: :first)
+
+    expect(page).to have_text('Edit supplier')
+  end
 end


### PR DESCRIPTION
## Description
- [NRMI-79: Link supplier on unfinished tasks](https://crowncommercialservice.atlassian.net/browse/NRMI-79)

## Why was the change made?
Ease of navigation/ability for admin user

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual testing
