### PR TITLE
Feature/nrmi 89 add error message on create user

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,8 @@ gem 'aasm'
 
 gem 'bootsnap', '~> 1.11', '>= 1.11.1', require: false
 
+gem 'email_validator', require: 'email_validator/strict'
+
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 # gem 'jbuilder', '~> 2.7', '>= 2.7.0'
 gem 'jbuilder', '~> 2.12', '>= 2.12.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -170,6 +170,8 @@ GEM
       dotenv (= 3.1.2)
       railties (>= 6.1)
     drb (2.2.1)
+    email_validator (2.2.4)
+      activemodel
     erubi (1.12.0)
     et-orbi (1.2.7)
       tzinfo
@@ -603,6 +605,7 @@ DEPENDENCIES
   climate_control
   database_cleaner (~> 2.0, >= 2.0.2)
   dotenv-rails (>= 3.1.1)
+  email_validator
   factory_bot_rails (~> 6.4, >= 6.4.2)
   haml-rails (>= 2.1.0)
   hashdiff

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :tasks, through: :suppliers
   has_many :customer_effort_scores, dependent: :nullify
   validates :name, presence: true
-  validates :email, email: {mode: :strict}, presence: true, uniqueness: { case_sensitive: false }
+  validates :email, email: { mode: :strict }, presence: true, uniqueness: { case_sensitive: false }
 
   scope :active, -> { where.not(auth_id: nil) }
   scope :inactive, -> { where(auth_id: nil) }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,7 @@ class User < ApplicationRecord
   has_many :tasks, through: :suppliers
   has_many :customer_effort_scores, dependent: :nullify
   validates :name, presence: true
-  validates :email, presence: true, uniqueness: { case_sensitive: false }, format: { with: URI::MailTo::EMAIL_REGEXP }
+  validates :email, email: {mode: :strict}, presence: true, uniqueness: { case_sensitive: false }
 
   scope :active, -> { where.not(auth_id: nil) }
   scope :inactive, -> { where(auth_id: nil) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,6 +11,14 @@ RSpec.describe User, type: :model do
       expect(new_user).not_to be_valid
       expect(new_user.errors[:email]).to be_present
     end
+
+    it 'fails for invalid address formats' do
+      user = FactoryBot.create(:user)
+      user.email = 'somebody@example'
+
+      expect(user).not_to be_valid
+      expect(user.errors[:email]).to be_present
+    end
   end
 
   describe '#name=' do


### PR DESCRIPTION
## Description
- [NRMI-89: missing error message for invalid emails when creating new user](https://crowncommercialservice.atlassian.net/browse/NRMI-89)

## Why was the change made?
Corrected issue where an incomplete email address causes a 'success' message when adding a new user. Decreases support team confusion, reduces support query repetition.

## Are there any dependencies required for this change?
No.

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Unit and manual testing.
