### PR TITLE
NRMI-138

### DIFF
--- a/app/serializable/serializable_task.rb
+++ b/app/serializable/serializable_task.rb
@@ -15,7 +15,7 @@ class SerializableTask < JSONAPI::Serializable::Resource
         {
           id: submission.id,
           submitted_at: submission.submitted_at,
-          submitted_by: submission.submitted_by.email,
+          submitted_by: submission.submitted_by&.email,
           invoice_total: submission.invoice_total,
           file_name: submission.filename,
           invoice_details: submission.invoice_details,

--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -16,9 +16,14 @@
             spend
       %td.govuk-table__cell
         = task.active_submission.created_at.to_fs(:date_with_utc_time)
-        %br
-        %small
-          = task.active_submission.created_by.email.scan(/.{1,20}/).join("\n")
+        - if task.active_submission.created_by
+          %br
+          %small
+            = task.active_submission.created_by.email.scan(/.{1,20}/).join("\n") 
+        - else
+          %br
+          %small
+            Unknown submitter
       %td.govuk-table__cell{:colspan => 2}
         %small
           = task.active_submission.aasm_state.titlecase
@@ -55,9 +60,14 @@
                 spend
           %td.govuk-table__cell
             = submission.created_at.to_fs(:date_with_utc_time)
-            %br
-            %small
-              = submission.created_by.email.scan(/.{1,20}/).join("\n")
+            - if submission.created_by
+              %br
+              %small
+                = submission.created_by.email.scan(/.{1,20}/).join("\n")
+            - else
+              %br
+              %small
+                Unknown submitter
           %td.govuk-table__cell{:colspan => 2}
             %small
               = submission.aasm_state.titlecase


### PR DESCRIPTION
## Description
-[RMI-138: Enable supplier's to view/resubmit tasks pre-dating Jan-2019](https://crowncommercialservice.atlassian.net/browse/NRMI-138)

## Why was the change made?
The ability for suppliers and admin users to make corrections and view, respectively, tasks in RMI pre-dating Jan 2019.
- Completeness of income, audit trail, and remove a gap in the task history.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [x] Bug fix

## How was the change tested?
Manually
