### PR TITLE
Release/164

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Change Log
 
+## [release-163] - 2025-03-18
+
+- NRMI-79: link supplier on unfinished tasks page
+- NRMI-80: select valid outstanding tasks for bulk report no business
+- NRMI-81: confirm/cancel bulk report no business
+- NRMI-82: bulk tasks no business completed view
+- NRMI-89: add error message for invalid emails in create user
+- NRMI-117: fix for missing payment status in workday response issue
+- NRMI-98: change logo
+- NRMI-94: fix accessibility issue
+- NRMI-93: fix table overflow in mobile view
+
 ## [release-162] - 2024-12-09
 
 - NRMI-78: release notes feature
@@ -1077,6 +1089,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-163]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-162...release-163
 [release-162]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-161...release-162
 [release-161]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-160...release-161
 [release-160]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-159...release-160

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## [release-164] - 2025-03-31
+
+- NRMI-138: Enable supplier's to view/resubmit tasks pre-dating Jan-2019
+
 ## [release-163] - 2025-03-18
 
 - NRMI-79: link supplier on unfinished tasks page
@@ -1089,6 +1093,7 @@ this should have been released in release 45 but wasn't actually merged
 
 Initial release
 
+[release-164]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-163...release-164
 [release-163]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-162...release-163
 [release-162]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-161...release-162
 [release-161]: https://github.com/Crown-Commercial-Service/DataSubmissionServiceAPI/compare/release-160...release-161

--- a/app/assets/stylesheets/components/table/_table.scss
+++ b/app/assets/stylesheets/components/table/_table.scss
@@ -1,5 +1,13 @@
 @import "govuk-frontend/govuk/components/table/table";
 
+.govuk-table {
+  @media (max-width: 768px) {
+    display: block;
+    height: 100%;
+    overflow: auto;
+  }
+}
+
 .govuk-table__cell--numeric {
   @include govuk-font($size: false);
 }

--- a/app/serializable/serializable_task.rb
+++ b/app/serializable/serializable_task.rb
@@ -15,7 +15,7 @@ class SerializableTask < JSONAPI::Serializable::Resource
         {
           id: submission.id,
           submitted_at: submission.submitted_at,
-          submitted_by: submission.submitted_by.email,
+          submitted_by: submission.submitted_by&.email,
           invoice_total: submission.invoice_total,
           file_name: submission.filename,
           invoice_details: submission.invoice_details,

--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -16,9 +16,14 @@
             spend
       %td.govuk-table__cell
         = task.active_submission.created_at.to_fs(:date_with_utc_time)
-        %br
-        %small
-          = task.active_submission.created_by.email.scan(/.{1,20}/).join("\n")
+        - if task.active_submission.created_by
+          %br
+          %small
+            = task.active_submission.created_by.email.scan(/.{1,20}/).join("\n") 
+        - else
+          %br
+          %small
+            Unknown submitter
       %td.govuk-table__cell{:colspan => 2}
         %small
           = task.active_submission.aasm_state.titlecase
@@ -55,9 +60,14 @@
                 spend
           %td.govuk-table__cell
             = submission.created_at.to_fs(:date_with_utc_time)
-            %br
-            %small
-              = submission.created_by.email.scan(/.{1,20}/).join("\n")
+            - if submission.created_by
+              %br
+              %small
+                = submission.created_by.email.scan(/.{1,20}/).join("\n")
+            - else
+              %br
+              %small
+                Unknown submitter
           %td.govuk-table__cell{:colspan => 2}
             %small
               = submission.aasm_state.titlecase


### PR DESCRIPTION
## Description
-[RMI-138: Enable supplier's to view/resubmit tasks pre-dating Jan-2019](https://crowncommercialservice.atlassian.net/browse/NRMI-138)

## Why was the change made?
The ability for suppliers and admin users to make corrections and view, respectively, tasks in RMI pre-dating Jan 2019.
- Completeness of income, audit trail, and remove a gap in the task history.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [x] Bug fix

## How was the change tested?
Manually