### PR TITLE
Feature/nrmi 144 email spacing issue

### DIFF
--- a/app/views/admin/suppliers/_task.html.haml
+++ b/app/views/admin/suppliers/_task.html.haml
@@ -19,7 +19,7 @@
         - if task.active_submission.created_by
           %br
           %small
-            = task.active_submission.created_by.email.scan(/.{1,20}/).join("\n") 
+            = task.active_submission.created_by.email.gsub("-", "&#8209").scan(/.{1,20}/).join("<br>").html_safe 
         - else
           %br
           %small


### PR DESCRIPTION
## Description
- [NRMI-144: Odd spaces in some emails on supplier pages](https://crowncommercialservice.atlassian.net/browse/NRMI-144)

## Why was the change made?
Correct display of emails 

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

## How was the change tested?
Manually
