### PR TITLE
Feature/nrmi 116 add user with pre selected supplier

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -13,12 +13,17 @@ class Admin::UsersController < AdminController
     @user = User.new(user_params)
   rescue StandardError
     @user = User.new
+    @supplier_sf_id = params[:supplier_sf_id].presence
   end
 
   def build
     @user = User.new(user_params)
+    @selected_supplier_ids = Array(params[:supplier_sf_id])
 
-    if @user.valid?
+    if @user.valid? && params[:supplier_sf_id].present?
+      @suppliers = Supplier.where(salesforce_id: @selected_supplier_ids)
+      render :confirm
+    elsif @user.valid?
       @suppliers = Supplier.order(:name).search(params[:search]).page(params[:supplier_page])
       respond_to do |format|
         format.html { render :select_suppliers }

--- a/app/controllers/v1/suppliers_controller.rb
+++ b/app/controllers/v1/suppliers_controller.rb
@@ -1,0 +1,7 @@
+class V1::SuppliersController < ApiController
+  def index
+    suppliers = current_user.suppliers
+
+    render jsonapi: suppliers
+  end
+end

--- a/app/serializable/serializable_user.rb
+++ b/app/serializable/serializable_user.rb
@@ -1,4 +1,4 @@
 class SerializableUser < JSONAPI::Serializable::Resource
   type 'users'
-  attributes :multiple_suppliers?, :name, :email
+  attributes :multiple_suppliers?, :name, :email, :created_at
 end

--- a/app/views/admin/suppliers/show.html.haml
+++ b/app/views/admin/suppliers/show.html.haml
@@ -12,6 +12,8 @@
           = link_to 'Edit supplier', edit_admin_supplier_path(@supplier)
         %li.govuk-page-actions--action
           = link_to "Add a missing task", new_admin_supplier_task_path(@supplier)
+        %li.govuk-page-actions--action
+          = link_to "Add a new user", new_admin_user_path(supplier_sf_id: @supplier.salesforce_id)
 
 
 .govuk-tabs{"data-module" => "govuk-tabs"}

--- a/app/views/admin/users/new.html.haml
+++ b/app/views/admin/users/new.html.haml
@@ -1,9 +1,10 @@
 .govuk-grid-row
   .govuk-grid-column-two-thirds
-    = link_to 'Back', admin_users_path, { class: 'govuk-back-link govuk-!-margin-bottom-5', title: 'Back to users' }
+    = link_to 'Back', request.referer.present? ? request.referer : admin_users_path, { class: 'govuk-back-link govuk-!-margin-bottom-5', title: 'Back to previous page' }
 
     %h1.govuk-heading-l Add a new user
 
+    - button_text = @supplier_sf_id ? "Confirm" : "Select suppliers"
     = form_with model: @user, url: build_admin_users_path, method: :post, local: true do |f|
     
       = render partial: 'shared/error_summary', locals: { entity: @user } if @user.errors.present?
@@ -20,4 +21,6 @@
           %span.govuk-error-message= @user.errors[:email].first
         = f.email_field :email, class: "govuk-input"
 
-      = f.submit "Select suppliers", class: "govuk-button"
+      = hidden_field_tag :supplier_sf_id, @supplier_sf_id if @supplier_sf_id
+
+      = f.submit button_text, class: "govuk-button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -23,6 +23,8 @@ Rails.application.routes.draw do
   namespace :v1, defaults: { format: :json } do
     resources :users, only: %i[index]
 
+    resources :suppliers, only: %i[index]
+
     resources :submissions, only: %i[show create update] do
       member do
         post 'complete', to: 'submissions#complete'

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -63,7 +63,7 @@ RSpec.feature 'Adding a user' do
       expect(page).to have_content(email)
       expect(page).to have_content(supplier_1.name)
       click_button 'Create user'
-      expect(page).to have_content('User created successfully with linked suppliers.') 
+      expect(page).to have_content('User created successfully with linked suppliers.')
     end
   end
 

--- a/spec/features/adding_a_user_spec.rb
+++ b/spec/features/adding_a_user_spec.rb
@@ -15,37 +15,56 @@ RSpec.feature 'Adding a user' do
     sign_in_as_admin
   end
 
-  scenario 'successfully' do
-    click_on 'Users'
-    click_on 'Add a new user'
+  context 'successfully' do
+    scenario 'from scratch' do
+      click_on 'Users'
+      click_on 'Add a new user'
 
-    fill_in 'Name', with: 'New User'
-    fill_in 'Email address', with: email
+      fill_in 'Name', with: 'New User'
+      fill_in 'Email address', with: email
 
-    click_button 'Select suppliers'
+      click_button 'Select suppliers'
 
-    expect(page).to have_content(supplier_1.name)
-    expect(page).to have_content(supplier_1.salesforce_id)
-    expect(page).to have_content(supplier_2.name)
-    expect(page).to have_content(supplier_2.salesforce_id)
+      expect(page).to have_content(supplier_1.name)
+      expect(page).to have_content(supplier_1.salesforce_id)
+      expect(page).to have_content(supplier_2.name)
+      expect(page).to have_content(supplier_2.salesforce_id)
 
-    fill_in 'Search', with: '2'
-    click_button 'Search'
+      fill_in 'Search', with: '2'
+      click_button 'Search'
 
-    expect(page).not_to have_content(supplier_1.name)
-    expect(page).to have_content(supplier_2.name)
+      expect(page).not_to have_content(supplier_1.name)
+      expect(page).to have_content(supplier_2.name)
 
-    check "supplier_#{supplier_2.salesforce_id}"
+      check "supplier_#{supplier_2.salesforce_id}"
 
-    click_button 'Confirm'
+      click_button 'Confirm'
 
-    expect(page).to have_content('New User')
-    expect(page).to have_content('new@example.com')
-    expect(page).to have_content(supplier_2.name)
+      expect(page).to have_content('New User')
+      expect(page).to have_content('new@example.com')
+      expect(page).to have_content(supplier_2.name)
 
-    click_button 'Create user'
+      click_button 'Create user'
 
-    expect(page).to have_content('User created successfully with linked suppliers.')
+      expect(page).to have_content('User created successfully with linked suppliers.')
+    end
+
+    scenario 'from a supplier' do
+      visit admin_supplier_path(supplier_1)
+
+      click_on 'Add a new user'
+
+      fill_in 'Name', with: 'New User'
+      fill_in 'Email address', with: email
+
+      click_button 'Confirm'
+
+      expect(page).to have_content('New User')
+      expect(page).to have_content(email)
+      expect(page).to have_content(supplier_1.name)
+      click_button 'Create user'
+      expect(page).to have_content('User created successfully with linked suppliers.') 
+    end
   end
 
   context 'when no name is provided' do

--- a/spec/requests/v1/suppliers_spec.rb
+++ b/spec/requests/v1/suppliers_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe '/v1' do
+  let(:user) { FactoryBot.create(:user) }
+
+  describe 'GET /v1/suppliers' do
+    it 'returns 401 if authentication needed and not provided' do
+      ClimateControl.modify API_PASSWORD: 'sdfhg' do
+        get '/v1/suppliers', headers: { 'X-Auth-Id' => JWT.encode(user.auth_id, 'test') }
+        expect(response.status).to eq(401)
+      end
+    end
+
+    it 'returns 500 if X-Auth-Id header missing' do
+      expect { get '/v1/suppliers' }.to raise_error(ActionController::BadRequest)
+    end
+
+    it 'returns ok if authentication needed and provided' do
+      ClimateControl.modify API_PASSWORD: 'sdfhg' do
+        get '/v1/suppliers', params: {}, headers: {
+          HTTP_AUTHORIZATION: ActionController::HttpAuthentication::Basic.encode_credentials('dxw', 'sdfhg'),
+          'X-Auth-Id' => JWT.encode(user.auth_id, 'test')
+        }
+        expect(response).to be_successful
+      end
+    end
+
+    it 'returns a list of suppliers' do
+      supplier1 = FactoryBot.create(:supplier, name: 'Supplier One')
+      supplier2 = FactoryBot.create(:supplier, name: 'Supplier Two')
+      user.suppliers << supplier1
+      user.suppliers << supplier2
+
+      get '/v1/suppliers', headers: { 'X-Auth-Id' => JWT.encode(user.auth_id, 'test') }
+
+      expect(response).to be_successful
+
+      expect(json['data'].map { |data| data['id'] }).to contain_exactly(supplier1.id, supplier2.id)
+
+      json_supplier = json['data'].find { |data| data['id'] == supplier1.id }
+      expect(json_supplier).to have_attribute(:name).with_value(supplier1.name)
+    end
+  end
+end


### PR DESCRIPTION
## Description
- [NRMI-116: new ad hoc 'add new user' journey with pre-selected supplier](https://crowncommercialservice.atlassian.net/browse/NRMI-116)

## Why was the change made?
Improved ad hoc user creation journey, improved admin user experience, decreased time spent on support tickets, decreased chance for human error when selecting suppliers to add to a new account.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature and manual tests
