### PR TITLE
NRMI-166: Add archived agreement status

### DIFF
--- a/app/helpers/frameworks_helper.rb
+++ b/app/helpers/frameworks_helper.rb
@@ -1,5 +1,9 @@
 module FrameworksHelper
   def published_status(framework)
-    framework.published ? 'Published' : 'New'
+    framework.aasm_state
+  end
+
+  def framework_not_archived?(framework)
+    framework.aasm_state != 'archived'
   end
 end

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -1,4 +1,19 @@
 class Framework < ApplicationRecord
+  include AASM
+
+  aasm column: 'aasm_state' do
+    state :new, initial: true
+    state :published
+    state :archived
+
+    event :publish do
+      transitions from: %i[new archived], to: :published, guard: :load_lots!
+    end 
+    event :archive do
+      transitions from: %i[published], to: :archived
+    end
+  end
+
   has_many :lots, dependent: :nullify, class_name: 'FrameworkLot'
   has_many :submissions, dependent: :nullify
 
@@ -10,8 +25,9 @@ class Framework < ApplicationRecord
 
   validates :definition_source, fdl: true, allow_nil: true
 
-  scope :published, -> { where(published: true) }
-  scope :unpublished, -> { where(published: false) }
+  scope :published, -> { where(aasm_state: 'published') }
+  scope :archived, -> { where(aasm_state: 'archived') }
+  scope :new_state, -> { where(aasm_state: 'new') }
 
   has_one_attached :template_file
 
@@ -63,11 +79,6 @@ class Framework < ApplicationRecord
     end
   end
 
-  def publish!
-    load_lots!
-    update(published: true)
-  end
-
   def load_lots!
     generator = Framework::Definition::Generator.new(definition_source, Rails.logger)
     fdl_lots = generator.definition.lots || {}
@@ -94,5 +105,9 @@ class Framework < ApplicationRecord
     else
       update(definition_source: definition_source)
     end
+  end
+
+  def can_be_archived?
+    published? && agreements.active.none? 
   end
 end

--- a/app/views/admin/frameworks/archive_confirmation.html.haml
+++ b/app/views/admin/frameworks/archive_confirmation.html.haml
@@ -1,0 +1,10 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = link_to 'Back', admin_framework_path(@framework), { class: 'govuk-back-link govuk-!-margin-bottom-5', title: 'Back to agreement' }
+
+    %h2.govuk-heading-l
+      Are you sure you want to archive 
+      = "#{@framework.short_name} #{@framework.name}?"
+
+    = form_with url: archive_admin_framework_path(@framework), method: :post do |f|
+      = f.submit "Confirm", class: "govuk-button"

--- a/app/views/admin/frameworks/show.html.haml
+++ b/app/views/admin/frameworks/show.html.haml
@@ -9,7 +9,8 @@
       %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
       %ul.govuk-page-actions--actions
         %li.govuk-page-actions--action
-          = link_to 'Edit definition', edit_admin_framework_path(@framework)
+          - if framework_not_archived?(@framework)
+            = link_to 'Edit definition', edit_admin_framework_path(@framework)
         %li.govuk-page-actions--action
           = link_to 'Download users (CSV)', users_admin_framework_reports_path(@framework)
         %li.govuk-page-actions--action
@@ -17,6 +18,11 @@
         %li.govuk-page-actions--action
           - if @framework.template_file.attached?
             = link_to 'Download template (excel document)', download_template_admin_framework_path(@framework, disposition: "attachment"), {'aria-label' => "Download excel document template for #{@framework.short_name} #{@framework.name}"}
+        %li.govuk-page-actions--action
+          - if @framework.can_be_archived?
+            = link_to 'Archive agreement', archive_confirmation_admin_framework_path(@framework)
+          - if @framework.archived?
+            = link_to 'Unarchive agreement', unarchive_confirmation_admin_framework_path(@framework)
 
 .govuk-grid-row
   .govuk-grid-column-full
@@ -27,36 +33,37 @@
 
       %textarea#code-editor{ readonly: true }= @definition_source
 
-.govuk-grid-row
-  .govuk-grid-column-full
-    = simple_form_for [:admin, @framework] do |form|
-      %fieldset.govuk-fieldset
-        %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
-          %h2.govuk-fieldset__heading
-            Template
-
-        - if @framework.template_file.attached?
-          %table.govuk-table
-            %thead.govuk-table__head
-              %tr.govuk-table__row
-                %th.govuk-table__header Name
-                %th.govuk-table__header Uploaded
-            %tbody.govuk-table__body
-              %td.govuk-table__cell= @framework.template_file.filename
-              %td.govuk-table__cell= @framework.template_file.attachment.created_at.to_fs(:date_with_utc_time)
-
-          = form.input :template_file, label: 'Replace file', hide_optional: true
-        - else
-          = form.input :template_file, label: 'Choose a file to upload. Accepted file types are Microsoft Excel (.xls or .xlsx).', hide_optional: true
-
-        = form.button :submit, value: 'Upload Template', data: { disable_with: "Update Agreement" }
-
-- unless @framework.published
+- if framework_not_archived?(@framework)
   .govuk-grid-row
     .govuk-grid-column-full
-      = simple_form_for [:admin, @framework], url: publish_admin_framework_path(@framework) do |form|
-        %fieldset.govuk-fieldset
+      = simple_form_for [:admin, @framework] do |form|
+        %fieldset.govuk-fieldset{class: 'govuk-!-margin-top-5'}
           %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
             %h2.govuk-fieldset__heading
-              Publish
-          = form.button :submit, value: 'Publish agreement', data: { disable_with: "Update Agreement" }
+              Template
+
+          - if @framework.template_file.attached?
+            %table.govuk-table
+              %thead.govuk-table__head
+                %tr.govuk-table__row
+                  %th.govuk-table__header Name
+                  %th.govuk-table__header Uploaded
+              %tbody.govuk-table__body
+                %td.govuk-table__cell= @framework.template_file.filename
+                %td.govuk-table__cell= @framework.template_file.attachment.created_at.to_fs(:date_with_utc_time)
+
+            = form.input :template_file, label: 'Replace file', hide_optional: true
+          - else
+            = form.input :template_file, label: 'Choose a file to upload. Accepted file types are Microsoft Excel (.xls or .xlsx).', hide_optional: true
+
+          = form.button :submit, value: 'Upload Template', data: { disable_with: "Update Agreement" }
+
+  - if @framework.new?
+    .govuk-grid-row
+      .govuk-grid-column-full
+        = simple_form_for [:admin, @framework], url: publish_admin_framework_path(@framework) do |form|
+          %fieldset.govuk-fieldset
+            %legend.govuk-fieldset__legend.govuk-fieldset__legend--l
+              %h2.govuk-fieldset__heading
+                Publish
+            = form.button :submit, value: 'Publish agreement', data: { disable_with: "Update Agreement" }

--- a/app/views/admin/frameworks/unarchive_confirmation.html.haml
+++ b/app/views/admin/frameworks/unarchive_confirmation.html.haml
@@ -1,0 +1,10 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = link_to 'Back', admin_framework_path(@framework), { class: 'govuk-back-link govuk-!-margin-bottom-5', title: 'Back to agreement' }
+
+    %h2.govuk-heading-l
+      Are you sure you want to unarchive 
+      = "#{@framework.short_name} #{@framework.name}?"
+
+    = form_with url: unarchive_admin_framework_path(@framework), method: :post do |f|
+      = f.submit "Confirm", class: "govuk-button"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,10 @@ Rails.application.routes.draw do
         patch :update_fdl
         patch :publish
         get :download_template
+        get :archive_confirmation
+        post :archive
+        get :unarchive_confirmation
+        post :unarchive
       end
     end
 

--- a/db/migrate/20250917145331_add_aasm_state_to_frameworks.rb
+++ b/db/migrate/20250917145331_add_aasm_state_to_frameworks.rb
@@ -1,0 +1,15 @@
+class AddAasmStateToFrameworks < ActiveRecord::Migration[8.0]
+  def up
+    add_column :frameworks, :aasm_state, :string, null: false, default: 'new'
+    add_index :frameworks, :aasm_state
+
+    Framework.reset_column_information
+    Framework.where(published: true).update_all(aasm_state: 'published')
+    Framework.where(published: false).update_all(aasm_state: 'new')
+  end
+
+  def down
+    remove_index :frameworks, :aasm_state
+    remove_column :frameworks, :aasm_state
+  end
+end

--- a/db/migrate/20250922123744_remove_published_from_frameworks.rb
+++ b/db/migrate/20250922123744_remove_published_from_frameworks.rb
@@ -1,0 +1,5 @@
+class RemovePublishedFromFrameworks < ActiveRecord::Migration[8.0]
+  def change
+    remove_column :frameworks, :published
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.0].define(version: 2024_12_04_155125) do
+ActiveRecord::Schema[8.0].define(version: 2025_09_22_123744) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
   enable_extension "pg_catalog.plpgsql"
@@ -143,7 +143,8 @@ ActiveRecord::Schema[8.0].define(version: 2024_12_04_155125) do
     t.string "name"
     t.string "short_name", null: false
     t.text "definition_source", null: false
-    t.boolean "published", default: false
+    t.string "aasm_state", default: "new", null: false
+    t.index ["aasm_state"], name: "index_frameworks_on_aasm_state"
     t.index ["short_name"], name: "index_frameworks_on_short_name", unique: true
   end
 

--- a/spec/factories/framework.rb
+++ b/spec/factories/framework.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     sequence(:name) { |n| "G Cloud #{n}" }
 
     definition_source { DEFAULT_FDL.read }
-    published { true }
+    aasm_state { :published }
 
     transient do
       lot_count { 0 }

--- a/spec/features/admin_can_archive_a_framework_spec.rb
+++ b/spec/features/admin_can_archive_a_framework_spec.rb
@@ -1,0 +1,62 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can archive a framework' do
+  let!(:framework) do
+    create(:framework, aasm_state: aasm_state, short_name: 'RM999',
+      name: 'Framework to be published', definition_source: definition_source)
+  end
+  let(:definition_source) do
+    <<~FDL
+      Framework RM999 {
+        Name 'Framework to be published'
+        ManagementCharge 0.5% of 'Supplier Price'
+        Lots {
+          '1' -> 'Lot 1'
+          '2' -> 'Second Lot'
+        }
+         InvoiceFields {
+          InvoiceValue from 'Supplier Price'
+        }
+      }
+    FDL
+  end
+
+  before do
+    sign_in_as_admin
+  end
+
+  context 'there is an existing published framework' do
+    let(:aasm_state) { 'published' }
+
+    scenario 'everything is fine' do
+      visit admin_framework_path(framework)
+      click_link('Archive agreement')
+      expect(page).to have_content('Are you sure you want to archive RM999 Framework to be published?')
+      click_button('Confirm')
+      expect(page).to have_content('Framework archived successfully')
+    end
+  end
+
+  context 'there is an existing unpublished framework' do
+    let(:aasm_state) { 'new' }
+
+    scenario 'no link exists to archive' do
+      visit admin_framework_path(framework)
+      expect(page).to_not have_content('Archive agreement')
+    end
+  end
+
+  context 'there is an existing archived framework' do
+    let(:aasm_state) { 'archived' }
+
+    scenario 'no link exists to archive' do
+      visit admin_framework_path(framework)
+      expect(page).to_not have_content('Archive agreement')
+      expect(page).to have_content('Unarchive agreement')
+      click_link('Unarchive agreement')
+      expect(page).to have_content('Are you sure you want to unarchive RM999 Framework to be published?')
+      click_button('Confirm')
+      expect(page).to have_content('Framework unarchived successfully')
+    end
+  end
+end

--- a/spec/features/admin_can_bulk_deactivate_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_deactivate_suppliers_spec.rb
@@ -44,7 +44,7 @@ RSpec.feature 'Admin can bulk deactivate suppliers' do
   end
 
   context 'with a CSV which references an unpublished framework' do
-    before { fm1234.update(published: false) }
+    before { fm1234.update(aasm_state: 'archived') }
 
     scenario 'displays an error' do
       visit admin_suppliers_path

--- a/spec/features/admin_can_bulk_onboard_suppliers_spec.rb
+++ b/spec/features/admin_can_bulk_onboard_suppliers_spec.rb
@@ -86,7 +86,7 @@ RSpec.feature 'Admin can bulk on-board suppliers' do
   end
 
   context 'with a CSV which references an unpublished framework' do
-    before { fm1234.update(published: false) }
+    before { fm1234.update(aasm_state: 'archived') }
 
     scenario 'displays an error' do
       visit new_admin_supplier_bulk_onboard_path

--- a/spec/features/admin_can_bulk_remove_suppliers_from_framework_lots_spec.rb
+++ b/spec/features/admin_can_bulk_remove_suppliers_from_framework_lots_spec.rb
@@ -70,7 +70,7 @@ RSpec.feature 'Admin can bulk remove suppliers from lots' do
   end
 
   context 'with a CSV which references an unpublished framework' do
-    before { fm1234.update(published: false) }
+    before { fm1234.update(aasm_state: 'new') }
 
     scenario 'displays an error' do
       visit new_admin_supplier_bulk_lot_removal_path

--- a/spec/features/admin_can_edit_a_framework_spec.rb
+++ b/spec/features/admin_can_edit_a_framework_spec.rb
@@ -2,7 +2,7 @@ require 'rails_helper'
 
 RSpec.feature 'Admin can edit a framework' do
   let(:framework) do
-    create(:framework, published: published, short_name: 'RM999',
+    create(:framework, aasm_state: aasm_state, short_name: 'RM999',
       name: 'Framework to be changed', definition_source: existing_source)
   end
 
@@ -66,13 +66,13 @@ RSpec.feature 'Admin can edit a framework' do
     end
 
     context 'there is an existing unpublished framework' do
-      let(:published) { false }
+      let(:aasm_state) { 'new' }
 
       include_examples 'successful edit'
     end
 
     context 'there is an existing published framework' do
-      let(:published) { true }
+      let(:aasm_state) { 'published' }
 
       include_examples 'successful edit'
     end
@@ -93,7 +93,7 @@ RSpec.feature 'Admin can edit a framework' do
     end
 
     context 'there is an existing unpublished framework' do
-      let(:published) { false }
+      let(:aasm_state) { 'new' }
 
       scenario 'the existing framework is not updated' do
         # When I visit the frameworks page

--- a/spec/features/admin_can_list_frameworks_spec.rb
+++ b/spec/features/admin_can_list_frameworks_spec.rb
@@ -9,7 +9,7 @@ RSpec.feature 'Admin can list frameworks' do
     FactoryBot.create(:framework, name: 'Laundry Framework 1', short_name: 'RM1234')
     FactoryBot.create(:framework, name: 'Vehicle Purchase Framework 1', short_name: 'RM5678')
     # And there are some unpublished frameworks
-    FactoryBot.create(:framework, published: false, name: 'Vehicle Purchase Framework 2', short_name: 'RM5679')
+    FactoryBot.create(:framework, aasm_state: 'new', name: 'Vehicle Purchase Framework 2', short_name: 'RM5679')
   end
 
   scenario 'There are some published and unpublished agreements' do
@@ -21,19 +21,19 @@ RSpec.feature 'Admin can list frameworks' do
     within 'tbody > tr:nth-child(1)' do
       expect(page).to have_text('RM1234')
       expect(page).to have_text('Laundry Framework 1')
-      expect(page).to have_text('Published')
+      expect(page).to have_text('published')
     end
 
     within 'tbody > tr:nth-child(2)' do
       expect(page).to have_text('RM5678')
       expect(page).to have_text('Vehicle Purchase Framework 1')
-      expect(page).to have_text('Published')
+      expect(page).to have_text('published')
     end
 
     within 'tbody > tr:nth-child(3)' do
       expect(page).to have_text('RM5679')
       expect(page).to have_text('Vehicle Purchase Framework 2')
-      expect(page).to have_text('New')
+      expect(page).to have_text('new')
     end
   end
 

--- a/spec/features/admin_can_publish_a_framework_spec.rb
+++ b/spec/features/admin_can_publish_a_framework_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
-RSpec.feature 'Admin can edit a framework' do
+RSpec.feature 'Admin can publish a framework' do
   let!(:framework) do
-    create(:framework, published: published, short_name: 'RM999',
+    create(:framework, aasm_state: aasm_state, short_name: 'RM999',
       name: 'Framework to be published', definition_source: definition_source)
   end
   let(:definition_source) do
@@ -26,7 +26,7 @@ RSpec.feature 'Admin can edit a framework' do
   end
 
   context 'there is an existing unpublished framework' do
-    let(:published) { false }
+    let(:aasm_state) { 'new' }
 
     scenario 'everything is fine' do
       visit admin_framework_path(framework)
@@ -37,7 +37,7 @@ RSpec.feature 'Admin can edit a framework' do
   end
 
   context 'there is an existing published framework' do
-    let(:published) { true }
+    let(:aasm_state) { 'published' }
 
     scenario 'no link exists to publish' do
       visit admin_framework_path(framework)

--- a/spec/features/admin_can_upload_template_to_framework_spec.rb
+++ b/spec/features/admin_can_upload_template_to_framework_spec.rb
@@ -6,7 +6,7 @@ RSpec.feature 'Uploading a template to a Framework' do
   end
 
   context 'we have an unpublished framework' do
-    let!(:framework) { create(:framework, published: false) }
+    let!(:framework) { create(:framework, aasm_state: 'new') }
 
     scenario 'everything is fine' do
       visit admin_frameworks_path
@@ -18,7 +18,7 @@ RSpec.feature 'Uploading a template to a Framework' do
   end
 
   context 'we have a published framework' do
-    let!(:framework) { create(:framework, :with_attachment, published: true) }
+    let!(:framework) { create(:framework, :with_attachment, aasm_state: 'published') }
 
     scenario 'everything is fine' do
       visit admin_frameworks_path
@@ -30,7 +30,7 @@ RSpec.feature 'Uploading a template to a Framework' do
   end
 
   context 'when no file was provided' do
-    let!(:framework) { create(:framework, published: true) }
+    let!(:framework) { create(:framework, aasm_state: 'published') }
 
     it 'responds with a meaningful error message' do
       visit admin_frameworks_path
@@ -41,7 +41,7 @@ RSpec.feature 'Uploading a template to a Framework' do
     end
 
     context 'when file provided is not .xls or .xlsx' do
-      let!(:framework) { create(:framework, published: true) }
+      let!(:framework) { create(:framework, aasm_state: 'published') }
 
       it 'responds with a meaningful error message' do
         visit admin_frameworks_path

--- a/spec/models/offboard/deactivate_suppliers/row_spec.rb
+++ b/spec/models/offboard/deactivate_suppliers/row_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe Offboard::DeactivateSuppliers::Row do
     end
 
     context 'with a framework that is not published' do
-      before { framework.update(published: false) }
+      before { framework.update(aasm_state: 'new') }
 
       it 'raises an ActiveRecord::RecordNotFound exception' do
         expect { row.offboard! }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/models/offboard/deactivate_suppliers_spec.rb
+++ b/spec/models/offboard/deactivate_suppliers_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Offboard::DeactivateSuppliers do
 
     context 'when the CSV references a framework that is not published' do
       it 'raises an error' do
-        framework.update(published: false)
+        framework.update(aasm_state: 'archived')
 
         expect { offboarder.run }.to raise_error(ActiveRecord::RecordNotFound)
       end

--- a/spec/models/offboard/remove_suppliers_from_lots/row_spec.rb
+++ b/spec/models/offboard/remove_suppliers_from_lots/row_spec.rb
@@ -61,7 +61,7 @@ RSpec.describe Offboard::RemoveSuppliersFromLots::Row do
     end
 
     context 'with a framework that is not published' do
-      before { framework.update(published: false) }
+      before { framework.update(aasm_state: 'archived') }
 
       it 'raises an ActiveRecord::RecordNotFound exception' do
         expect { row.offboard! }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/models/offboard/remove_suppliers_from_lots_spec.rb
+++ b/spec/models/offboard/remove_suppliers_from_lots_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Offboard::RemoveSuppliersFromLots do
 
     context 'when the CSV references a framework that is not published' do
       it 'raises an error' do
-        framework.update(published: false)
+        framework.update(aasm_state: 'archived')
 
         expect { offboarder.run }.to raise_error(ActiveRecord::RecordNotFound)
       end

--- a/spec/models/onboard/framework_suppliers/row_spec.rb
+++ b/spec/models/onboard/framework_suppliers/row_spec.rb
@@ -106,7 +106,7 @@ RSpec.describe Onboard::FrameworkSuppliers::Row do
     end
 
     context 'with a framework that is not published' do
-      before { framework.update(published: false) }
+      before { framework.update(aasm_state: 'archived') }
 
       it 'raises an ActiveRecord::RecordNotFound exception' do
         expect { row.onboard! }.to raise_error(ActiveRecord::RecordNotFound)

--- a/spec/models/onboard/framework_suppliers_spec.rb
+++ b/spec/models/onboard/framework_suppliers_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe Onboard::FrameworkSuppliers do
     context 'when the CSV references a framework that is not published' do
       let(:csv_path) { Rails.root.join('spec', 'fixtures', 'framework_suppliers.csv') }
 
-      before { framework.update!(published: false) }
+      before { framework.update!(aasm_state: 'archived') }
 
       it 'rolls back any changes to the database' do
         supplier_count_before = Supplier.count

--- a/spec/models/task/overdue_user_notification_list_spec.rb
+++ b/spec/models/task/overdue_user_notification_list_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe Task::OverdueUserNotificationList do
         framework1 = create :framework, short_name: 'RM0001', name: 'Framework 1'
         framework2 = create :framework, short_name: 'RM0002', name: 'Framework 2'
         framework3 = create :framework, short_name: 'COMPLETE0001'
-        create :framework, short_name: 'NOTPUBLISHED0001', published: false
+        create :framework, short_name: 'NOTPUBLISHED0001', aasm_state: 'new'
 
         supplier_a = create(:supplier, name: 'Supplier A')
         supplier_b = create(:supplier, name: 'Supplier B')

--- a/spec/requests/v1/frameworks_spec.rb
+++ b/spec/requests/v1/frameworks_spec.rb
@@ -2,9 +2,9 @@ require 'rails_helper'
 
 RSpec.describe '/v1' do
   before do
-    create(:framework, published: true)
-    create(:framework, published: true)
-    create(:framework, published: false)
+    create(:framework, aasm_state: 'published')
+    create(:framework, aasm_state: 'published')
+    create(:framework, aasm_state: 'new')
   end
 
   describe 'GET /v1/frameworks' do


### PR DESCRIPTION
## Description
- [NRMI-166: Add archived agreement status](https://crowncommercialservice.atlassian.net/browse/NRMI-166)

## Why was the change made?
So that no suppliers can be added to the agreement once it has been ‘archived’ and the experience of navigating the 'Agreements' list is improved.

## Are there any dependencies required for this change?
Migrations must be run once deployed

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature, unit and manual tests
