### PR TITLE
Feature/nrmi 252 add archiving error messaging

### DIFF
--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -80,6 +80,7 @@ class Admin::FrameworksController < AdminController
 
   def archive_confirmation; end
 
+  # rubocop:disable Metrics/AbcSize
   def archive
     @framework.errors.clear
 
@@ -96,6 +97,7 @@ class Admin::FrameworksController < AdminController
 
     redirect_to admin_framework_path(@framework)
   end
+  # rubocop:enable Metrics/AbcSize
 
   def unarchive_confirmation; end
 

--- a/app/controllers/admin/frameworks_controller.rb
+++ b/app/controllers/admin/frameworks_controller.rb
@@ -81,12 +81,19 @@ class Admin::FrameworksController < AdminController
   def archive_confirmation; end
 
   def archive
-    if @framework.can_be_archived?
-      @framework.archive!
+    @framework.errors.clear
+
+    unless @framework.can_be_archived?
+      flash[:failure] = @framework.errors.full_messages.to_sentence
+      return redirect_to admin_framework_path(@framework)
+    end
+
+    if @framework.archive
       flash[:success] = 'Framework archived successfully.'
     else
-      flash[:failure] = 'Framework cannot be archived. Ensure it is published and has no active agreements.'
+      flash[:failure] = @framework.errors.full_messages.to_sentence.presence || 'Error archiving framework.'
     end
+
     redirect_to admin_framework_path(@framework)
   end
 

--- a/app/models/framework.rb
+++ b/app/models/framework.rb
@@ -108,6 +108,8 @@ class Framework < ApplicationRecord
   end
 
   def can_be_archived?
-    published? && agreements.active.none?
+    errors.add(:base, 'Framework must be published to be archived') unless published?
+    errors.add(:base, 'Framework cannot be archived while it has active agreements') unless agreements.active.none?
+    errors.empty?
   end
 end

--- a/spec/models/framework_spec.rb
+++ b/spec/models/framework_spec.rb
@@ -171,4 +171,26 @@ RSpec.describe Framework do
       expect(framework.definition).to eq(framework.definition)
     end
   end
+
+  describe '#can_be_archived?' do
+    let(:framework) { create(:framework) }
+
+    context 'when not published' do
+      before { framework.update(aasm_state: 'new') }
+
+      it 'returns false and adds an error' do
+        expect(framework.can_be_archived?).to eq(false)
+        expect(framework.errors[:base]).to include('Framework must be published to be archived')
+      end
+    end
+
+    context 'when published and has no active agreements' do
+      before { framework.update(aasm_state: 'published') }
+
+      it 'returns true' do
+        expect(framework.can_be_archived?).to eq(true)
+        expect(framework.errors[:base]).to be_empty
+      end
+    end
+  end
 end

--- a/spec/requests/admin/frameworks_spec.rb
+++ b/spec/requests/admin/frameworks_spec.rb
@@ -1,0 +1,49 @@
+require 'rails_helper'
+
+RSpec.describe 'Admin archives a framework', type: :request do
+  include SingleSignOnHelpers
+
+  before do
+    stub_govuk_bank_holidays_request
+    mock_sso_with(email: 'admin@example.com')
+    get '/auth/google_oauth2/callback'
+  end
+
+  let(:definition_source) do
+    <<~FDL
+      Framework RM999 {
+        Name 'Framework to be published'
+        ManagementCharge 0.5% of 'Supplier Price'
+        Lots {
+          '1' -> 'Lot 1'
+          '2' -> 'Second Lot'
+        }
+         InvoiceFields {
+          InvoiceValue from 'Supplier Price'
+        }
+      }
+    FDL
+  end
+
+  let!(:framework) do
+    create(:framework, aasm_state: 'published', short_name: 'RM999',
+      name: 'Framework to be published', definition_source: definition_source)
+  end
+
+  context 'when the framework has an active agreement' do
+    before do
+      supplier = create(:supplier, name: 'Test Supplier')
+      create(:agreement, framework: framework, supplier: supplier, active: true)
+    end
+
+    it 'cannot be archived and shows an error message' do
+      post archive_admin_framework_path(framework)
+
+      expect(response).to redirect_to admin_framework_path(framework)
+      follow_redirect!
+
+      expect(response.body).to include('Framework cannot be archived while it has active agreements')
+      expect(framework.reload.aasm_state).to eq('published')
+    end
+  end 
+end

--- a/spec/requests/admin/frameworks_spec.rb
+++ b/spec/requests/admin/frameworks_spec.rb
@@ -45,5 +45,5 @@ RSpec.describe 'Admin archives a framework', type: :request do
       expect(response.body).to include('Framework cannot be archived while it has active agreements')
       expect(framework.reload.aasm_state).to eq('published')
     end
-  end 
+  end
 end


### PR DESCRIPTION
## Description
- [NRMI-252: add helpful messaging when archiving fails](https://crowncommercialservice.atlassian.net/browse/NRMI-252)

## Why was the change made?
Incorrect messaging

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] Bug fix

 [ ] New feature 

 [ ] Breaking change 

 [ ] This change requires a documentation update

## How was the change tested?
Manual and unit testing
