### PR TITLE
Feature/nrmi 363 active urn list view

### DIFF
--- a/app/controllers/admin/urn_lists_controller.rb
+++ b/app/controllers/admin/urn_lists_controller.rb
@@ -1,5 +1,5 @@
 class Admin::UrnListsController < AdminController
-  before_action :find_latest_list, only: %i[index download]
+  before_action :find_latest_list, only: %i[index]
 
   def index
     @urn_lists = UrnList.order(created_at: :desc).page(params[:page])
@@ -19,11 +19,6 @@ class Admin::UrnListsController < AdminController
     end
   rescue ActionController::ParameterMissing
     redirect_to new_admin_urn_list_path, alert: 'Please choose a file to upload'
-  end
-
-  def download
-    resp = s3_client.get_object(bucket: bucket, key: @latest_urn_list.file_key)
-    send_data resp.body.read, filename: @latest_urn_list.file_name.to_s
   end
 
   private

--- a/app/controllers/admin/urns_controller.rb
+++ b/app/controllers/admin/urns_controller.rb
@@ -8,7 +8,7 @@ class Admin::UrnsController < AdminController
   end
 
   def download
-    send_data urn_csv, 
+    send_data urn_csv,
               type: 'text/csv',
               disposition: 'attachment',
               filename: "customer_urns_#{Time.zone.today}.csv"

--- a/app/controllers/admin/urns_controller.rb
+++ b/app/controllers/admin/urns_controller.rb
@@ -1,0 +1,28 @@
+require 'csv'
+
+class Admin::UrnsController < AdminController
+  def index
+    @search = params[:search].to_s.strip
+
+    @customers = Customer.where(deleted: false).order(:name).search(@search).page(params[:page])
+  end
+
+  def download
+    send_data urn_csv, 
+              type: 'text/csv',
+              disposition: 'attachment',
+              filename: "customer_urns_#{Time.zone.today}.csv"
+  end
+
+  private
+
+  def urn_csv
+    CSV.generate(headers: true) do |csv|
+      csv << ['URN', 'CustomerName', 'PostCode', 'Sector', 'Published']
+
+      Customer.where(deleted: false).order(:name).find_each do |customer|
+        csv << [customer.urn, customer.name, customer.postcode, customer.sector, customer.published]
+      end
+    end
+  end
+end

--- a/app/views/admin/urn_lists/index.html.haml
+++ b/app/views/admin/urn_lists/index.html.haml
@@ -9,9 +9,8 @@
       %ul.govuk-page-actions--actions
         %li.govuk-page-actions--action
           = link_to 'Add a new URN list', new_admin_urn_list_path
-        - if @latest_urn_list.present?
-          %li.govuk-page-actions--action
-            = link_to 'Download URN list', download_admin_urn_list_path(@latest_urn_list, disposition: "attachment"), {'aria-label' => 'Download latest URN list'}
+        %li.govuk-page-actions--action
+          = link_to 'View Active URN list', admin_urns_path
 
 .govuk-grid-row
   .govuk-grid-column-full

--- a/app/views/admin/urns/index.html.haml
+++ b/app/views/admin/urns/index.html.haml
@@ -1,0 +1,49 @@
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    = link_to 'Back', admin_urn_lists_path, { class: 'govuk-back-link govuk-!-margin-bottom-5', title: 'Back to URN list log' }
+
+    %h1.govuk-heading-xl Active URN list
+
+.govuk-grid-row
+  .govuk-grid-column-two-thirds
+    %h2.govuk-heading-s
+      Search
+    = form_with url: admin_urns_path, method: :get, local: true do
+      .ccs-search-form-group
+        %label.govuk-label.govuk-visually-hidden{for: 'search'} Search
+        %input#search{name: 'search', type: 'text', value: params[:search], class: ['govuk-!-width-two-thirds', 'govuk-input']}
+        %button.govuk-button Search
+
+  .govuk-grid-column-one-third
+    %nav.govuk-page-actions{"aria-labelledby" => "page-actions-title"}
+      %h2#page-actions-title.govuk-heading-s{"aria-label" => "Page actions"} Actions
+      %ul.govuk-page-actions--actions
+        %li.govuk-page-actions--action
+          = link_to 'Download Active URN list', download_admin_urns_path
+
+.govuk-grid-row
+  .govuk-grid-column-full
+    - if @customers.any?
+      %table.govuk-table{:class => 'govuk-!-margin-top-7'}
+        %thead.govuk-table__head
+          %tr.govuk-table__row
+            %th.govuk-table__header URN
+            %th.govuk-table__header Organisation name
+            %th.govuk-table__header Sector
+            %th.govuk-table__header Postcode
+            %th.govuk-table__header Published
+        %tbody.govuk-table__body
+          - @customers.each do |customer|
+            %tr.govuk-table__row
+              %td.govuk-table__cell= customer.urn
+              %td.govuk-table__cell= customer.name
+              %td.govuk-table__cell= customer.sector.titleize
+              %td.govuk-table__cell= customer.postcode
+              %td.govuk-table__cell= customer.published? ? 'true' : 'false'
+      %nav.pagination.ccs-pagination{"aria-label" => "Pagination", :role => "navigation"}
+        .ccs-pagination__summary= page_entries_info @customers, entry_name: "customer"
+        = paginate @customers
+
+    - else params[:search]
+      %p
+        No customers found for ‘#{params[:search]}’.

--- a/app/views/kaminari/_next_page.html.haml
+++ b/app/views/kaminari/_next_page.html.haml
@@ -6,4 +6,4 @@
 -#    per_page:      number of items to fetch per page
 -#    remote:        data-remote
 %span.next
-  = link_to_unless current_page.last?, t('Next »').html_safe, url, rel: 'next', remote: remote
+  = link_to_unless current_page.last?, t('Next »').html_safe, url, rel: 'next', remote: remote, class: 'ccs-pagination__link'

--- a/app/views/kaminari/_prev_page.html.haml
+++ b/app/views/kaminari/_prev_page.html.haml
@@ -7,4 +7,4 @@
 -#    remote:        data-remote
 %span.prev
   %a.ccs-pagination__link
-  = link_to_unless current_page.first?, t('« Previous').html_safe, url, rel: 'prev', remote: remote
+  = link_to_unless current_page.first?, t('« Previous').html_safe, url, rel: 'prev', remote: remote, class: 'ccs-pagination__link'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -165,11 +165,13 @@ Rails.application.routes.draw do
       end
     end
 
-    resources :urn_lists, only: %i[index new create] do
-      member do
+    resources :urns, only: %i[index] do
+      collection do
         get :download
       end
     end
+
+    resources :urn_lists, only: %i[index new create]
 
     resources :downloads, only: %i[index show new]
 

--- a/spec/features/admin_can_search_urns_spec.rb
+++ b/spec/features/admin_can_search_urns_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.feature 'Admin can search for URNs' do
+  before do
+    @customer1 = FactoryBot.create(:customer, urn: '123', name: 'Customer One', postcode: 'AB1 2CD', sector: :central_government)
+    @customer2 = FactoryBot.create(:customer, urn: '456', name: 'Customer Two', postcode: 'EF3 4GH', sector: :wider_public_sector)
+    @customer3 = FactoryBot.create(:customer, urn: '789', name: 'Customer Three', postcode: 'IJ5 6KL', sector: :wider_public_sector)
+    sign_in_as_admin
+  end
+
+  scenario 'Viewing all URNs' do
+    visit admin_urns_path
+    expect(page).to have_content '123'
+    expect(page).to have_content '456'
+    expect(page).to have_content '789'
+  end
+
+  scenario 'Searching by customer name' do
+    visit admin_urns_path
+    fill_in 'Search', with: 'One'
+    click_button 'Search'
+    expect(page).to have_content '123'
+    expect(page).to_not have_content '456'
+    expect(page).to_not have_content '789'
+  end
+
+  scenario 'Searching by URN' do
+    visit admin_urns_path
+    fill_in 'Search', with: '456'
+    click_button 'Search'
+    expect(page).to_not have_content '123'
+    expect(page).to have_content '456'
+    expect(page).to_not have_content '789'
+  end
+
+  scenario 'Searching by postcode' do
+    visit admin_urns_path
+    fill_in 'Search', with: 'IJ5 6KL'
+    click_button 'Search'
+    expect(page).to_not have_content '123'
+    expect(page).to_not have_content '456'
+    expect(page).to have_content '789'
+  end
+end

--- a/spec/features/admin_can_search_urns_spec.rb
+++ b/spec/features/admin_can_search_urns_spec.rb
@@ -2,9 +2,12 @@ require 'rails_helper'
 
 RSpec.feature 'Admin can search for URNs' do
   before do
-    @customer1 = FactoryBot.create(:customer, urn: '123', name: 'Customer One', postcode: 'AB1 2CD', sector: :central_government)
-    @customer2 = FactoryBot.create(:customer, urn: '456', name: 'Customer Two', postcode: 'EF3 4GH', sector: :wider_public_sector)
-    @customer3 = FactoryBot.create(:customer, urn: '789', name: 'Customer Three', postcode: 'IJ5 6KL', sector: :wider_public_sector)
+    @customer1 = FactoryBot.create(:customer, urn: '123', name: 'Customer One', postcode: 'AB1 2CD',
+sector: :central_government)
+    @customer2 = FactoryBot.create(:customer, urn: '456', name: 'Customer Two', postcode: 'EF3 4GH',
+sector: :wider_public_sector)
+    @customer3 = FactoryBot.create(:customer, urn: '789', name: 'Customer Three', postcode: 'IJ5 6KL',
+sector: :wider_public_sector)
     sign_in_as_admin
   end
 

--- a/spec/requests/admin/urns_spec.rb
+++ b/spec/requests/admin/urns_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+require 'csv'
+
+RSpec.describe 'Admin URNs', type: :request do
+  include SingleSignOnHelpers
+
+  before do
+    stub_govuk_bank_holidays_request
+    mock_sso_with(email: 'admin@example.com')
+    get '/auth/google_oauth2/callback'
+  end
+  
+  describe  'GET /admin/urns' do
+    it 'renders the URN search page' do
+      get admin_urns_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include('Active URN list')
+      expect(response.body).to include('Search')
+      expect(response.body).to include('Download Active URN list')
+    end
+  end
+
+  describe 'GET /admin/urns/download' do
+    let!(:active_customer) { create(:customer, urn: '123', name: 'Active Customer One', postcode: 'AB1 2CD', sector: :central_government) }
+    let!(:deleted_customer) { create(:customer, urn: '456', name: 'Deleted Customer', postcode: 'IJ5 6KL', sector: :wider_public_sector, deleted: true) }
+
+    it 'returns a CSV file with active customers' do
+      get download_admin_urns_path
+
+      expect(response).to have_http_status(:ok)
+      expect(response.headers['Content-Type']).to include('text/csv')
+      expect(response.headers['Content-Disposition']).to include("attachment; filename=\"customer_urns_#{Time.zone.today}.csv\"")
+
+      csv = CSV.parse(response.body, headers: true)
+      expect(csv.headers).to eq(['URN', 'CustomerName', 'PostCode', 'Sector', 'Published'])
+      expect(csv.length).to eq(1)
+
+      expect(csv[0]['URN']).to include('123')
+      expect(csv[0]['CustomerName']).to eq(active_customer.name)
+      expect(csv[0]['PostCode']).to eq(active_customer.postcode)
+      expect(csv[0]['Sector']).to eq(active_customer.sector)
+
+      # Ensure deleted customer is not included
+      csv.each do |row|
+        expect(row['URN']).not_to include('456')
+        expect(row['CustomerName']).not_to eq(deleted_customer.name)
+        expect(row['PostCode']).not_to eq(deleted_customer.postcode)
+      end
+    end
+  end
+end

--- a/spec/requests/admin/urns_spec.rb
+++ b/spec/requests/admin/urns_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe 'Admin URNs', type: :request do
     mock_sso_with(email: 'admin@example.com')
     get '/auth/google_oauth2/callback'
   end
-  
-  describe  'GET /admin/urns' do
+
+  describe 'GET /admin/urns' do
     it 'renders the URN search page' do
       get admin_urns_path
 
@@ -22,15 +22,20 @@ RSpec.describe 'Admin URNs', type: :request do
   end
 
   describe 'GET /admin/urns/download' do
-    let!(:active_customer) { create(:customer, urn: '123', name: 'Active Customer One', postcode: 'AB1 2CD', sector: :central_government) }
-    let!(:deleted_customer) { create(:customer, urn: '456', name: 'Deleted Customer', postcode: 'IJ5 6KL', sector: :wider_public_sector, deleted: true) }
+    let!(:active_customer) do
+      create(:customer, urn: '123', name: 'Active Customer One', postcode: 'AB1 2CD', sector: :central_government)
+    end
+    let!(:deleted_customer) do
+      create(:customer, urn: '456', name: 'Deleted Customer', postcode: 'IJ5 6KL', sector: :wider_public_sector,
+     deleted: true)
+    end
 
     it 'returns a CSV file with active customers' do
       get download_admin_urns_path
 
       expect(response).to have_http_status(:ok)
       expect(response.headers['Content-Type']).to include('text/csv')
-      expect(response.headers['Content-Disposition']).to include("attachment; filename=\"customer_urns_#{Time.zone.today}.csv\"")
+      expect(response.headers['Content-Disposition']).to include("filename=\"customer_urns_#{Time.zone.today}.csv\"")
 
       csv = CSV.parse(response.body, headers: true)
       expect(csv.headers).to eq(['URN', 'CustomerName', 'PostCode', 'Sector', 'Published'])


### PR DESCRIPTION
## Description
- [NRMI-363: searchable active URN list view and new download link](https://crowncommercialservice.atlassian.net/browse/NRMI-363)

## Why was the change made?
Also to enable Admin users to view and search the latest URN list within the service, including 'Published' value.

## Are there any dependencies required for this change?
No

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Feature, unit and manual testing.
