### PR TITLE
NRMI-41

### DIFF
--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -73,4 +73,22 @@ class V1::UsersController < ApiController
 
     render jsonapi: objects, class: { OpenStruct: SerializableUserAuthLog }, status: :ok
   end
+
+  def deactivate
+    user = User.find_by!(auth_id: current_auth_id)
+
+    unless user.can_deactivate?
+      return render jsonapi_errors: { user: ['Cannot be deactivated because they are the only user associated with their suppliers'] },
+             status: :unprocessable_entity
+    end
+
+    result = DeactivateUser.new(user: user).call
+
+    if result.success?
+      render jsonapi: user, status: :ok
+    else
+      render jsonapi_errors: { user: ['Could not be deactivated'] },
+             status: :unprocessable_entity
+    end
+  end
 end

--- a/app/controllers/v1/users_controller.rb
+++ b/app/controllers/v1/users_controller.rb
@@ -78,8 +78,10 @@ class V1::UsersController < ApiController
     user = User.find_by!(auth_id: current_auth_id)
 
     unless user.can_deactivate?
+      # rubocop:disable Layout/LineLength
       return render jsonapi_errors: { user: ['Cannot be deactivated because they are the only user associated with their suppliers'] },
-             status: :unprocessable_entity
+                    status: :unprocessable_entity
+      # rubocop:enable Layout/LineLength
     end
 
     result = DeactivateUser.new(user: user).call

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -40,4 +40,10 @@ class User < ApplicationRecord
   def active?
     !auth_id.nil?
   end
+
+  def can_deactivate?
+    suppliers.all? do |supplier|
+      supplier.active_users.where.not(id: id).exists?
+    end
+  end
 end

--- a/app/serializable/serializable_user.rb
+++ b/app/serializable/serializable_user.rb
@@ -1,4 +1,4 @@
 class SerializableUser < JSONAPI::Serializable::Resource
   type 'users'
-  attributes :multiple_suppliers?, :name, :email, :created_at
+  attributes :multiple_suppliers?, :can_deactivate?, :name, :email, :created_at
 end

--- a/app/services/deactivate_user.rb
+++ b/app/services/deactivate_user.rb
@@ -36,6 +36,6 @@ class DeactivateUser
   private
 
   def lock_linked_suppliers!
-    user.suppliers.lock.load 
+    user.suppliers.lock.load
   end
 end

--- a/app/services/deactivate_user.rb
+++ b/app/services/deactivate_user.rb
@@ -9,6 +9,13 @@ class DeactivateUser
     result = Result.new(true)
 
     User.transaction do
+      lock_linked_suppliers!
+
+      unless user.can_deactivate?
+        result.success = false
+        raise ActiveRecord::Rollback
+      end
+
       begin
         DeleteUserInAuth0.new(user: user).call
       rescue Auth0::Exception
@@ -16,9 +23,19 @@ class DeactivateUser
         Rails.logger.error("Error adding user #{user.email} to Auth0 during DeactivateUser")
         raise ActiveRecord::Rollback
       end
-      user.update(auth_id: nil)
+
+      unless user.update(auth_id: nil)
+        result.success = false
+        raise ActiveRecord::Rollback
+      end
     end
 
     result
+  end
+
+  private
+
+  def lock_linked_suppliers!
+    user.suppliers.lock.load 
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,6 +25,7 @@ Rails.application.routes.draw do
       collection do
         patch :update_name
         patch :update_email
+        patch :deactivate
         get :user_auth_logs
       end
     end

--- a/spec/models/offboard/deactivate_users_spec.rb
+++ b/spec/models/offboard/deactivate_users_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe Offboard::DeactivateUsers do
   end
 
   let!(:user) { FactoryBot.create(:user, name: 'User One', email: 'email_one@ccs.co.uk', suppliers: [supplier]) }
+  let!(:user_two) { FactoryBot.create(:user, name: 'User Two', email: 'email_two@ccs.co.uk', suppliers: [supplier]) }
 
   before do
     stub_auth0_token_request

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -53,6 +53,57 @@ RSpec.describe User, type: :model do
     end
   end
 
+  describe '#can_deactivate?' do
+    subject(:can_deactivate?) { user.can_deactivate? }
+
+    let(:user) { FactoryBot.create(:user) }
+
+    context 'when the user is the only active user for a supplier' do
+      before do
+        supplier = FactoryBot.create(:supplier)
+        user.suppliers << supplier
+      end
+
+      it { is_expected.to be_falsy }
+    end
+
+    context 'when the user is not the only active user for a supplier' do
+      before do
+        supplier = FactoryBot.create(:supplier)
+        user.suppliers << supplier
+        other_user = FactoryBot.create(:user)
+        other_user.suppliers << supplier
+      end
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'when another linked user is inactive' do
+      before do
+        supplier = FactoryBot.create(:supplier)
+        user.suppliers << supplier
+        other_user = FactoryBot.create(:user, :inactive)
+        other_user.suppliers << supplier
+      end
+
+      it { is_expected.to be_falsy }
+    end
+
+    context 'when one supplier has multiple active users and another has only one' do
+      before do
+        supplier1 = FactoryBot.create(:supplier)
+        user.suppliers << supplier1
+        other_user1 = FactoryBot.create(:user)
+        other_user1.suppliers << supplier1
+
+        supplier2 = FactoryBot.create(:supplier)
+        user.suppliers << supplier2
+      end
+
+      it { is_expected.to be_falsy }
+    end
+  end
+
   describe '.search' do
     let!(:bob) { FactoryBot.create(:user, name: 'Bob Booker', email: 'bob@sheffield.com') }
     let!(:bobby) { FactoryBot.create(:user, name: 'Bobby Brown', email: 'bobby_b_66@hotmail.com') }

--- a/spec/requests/v1/users_spec.rb
+++ b/spec/requests/v1/users_spec.rb
@@ -16,6 +16,8 @@ RSpec.describe '/v1' do
       expect(json['data'][0])
         .to have_attribute(:multiple_suppliers?)
         .with_value(false)
+      expect(json['data'][0])
+        .to have_attribute(:can_deactivate?)
     end
 
     it 'returns the details of the current user who belongs to more than one supplier' do
@@ -28,6 +30,22 @@ RSpec.describe '/v1' do
       expect(response).to be_successful
       expect(json['data'][0])
         .to have_attribute(:multiple_suppliers?)
+        .with_value(true)
+    end
+
+    it 'returns that the user can be deactivated if they are not the only active user for a supplier' do
+      user = FactoryBot.create(:user)
+      supplier = FactoryBot.create(:supplier)
+      user.suppliers << supplier
+      other_user = FactoryBot.create(:user)
+      other_user.suppliers << supplier
+
+      get '/v1/users', headers: { 'X-Auth-Id' => JWT.encode(user.auth_id, 'test') }
+
+      expect(json['data'].size).to eql 1
+      expect(response).to be_successful
+      expect(json['data'][0])
+        .to have_attribute(:can_deactivate?)
         .with_value(true)
     end
   end
@@ -123,6 +141,45 @@ RSpec.describe '/v1' do
             }
 
       expect(response.status).to eq 200
+    end
+  end
+
+  describe 'PATCH /v1/users/deactivate' do
+    let(:user) { FactoryBot.create(:user) }
+    let(:headers) { { 'X-Auth-Id' => JWT.encode(user.auth_id, 'test') } }
+
+    context 'when the user can be deactivated' do
+      before do
+        supplier = FactoryBot.create(:supplier)
+        user.suppliers << supplier
+        other_user = FactoryBot.create(:user)
+        other_user.suppliers << supplier
+      end
+
+      it 'deactivates the user' do
+        stub_auth0_token_request
+        stub_auth0_delete_user_request(user)
+
+        patch '/v1/users/deactivate', headers: headers
+
+        expect(response).to be_successful
+        expect(user.reload.auth_id).to be_nil
+      end
+    end
+
+    context 'when the user cannot be deactivated' do
+      before do
+        supplier = FactoryBot.create(:supplier)
+        user.suppliers << supplier
+      end
+
+      it 'returns an error' do
+        patch '/v1/users/deactivate', headers: headers
+
+        expect(response.status).to eq 422
+        expect(json['errors']).not_to be_empty
+        expect(user.reload.auth_id).not_to be_nil
+      end
     end
   end
 end

--- a/spec/services/deactivate_user_spec.rb
+++ b/spec/services/deactivate_user_spec.rb
@@ -1,8 +1,13 @@
 require 'rails_helper'
 
 RSpec.describe DeactivateUser do
+  let(:suppler) { create(:supplier) }
   let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
   before(:each) do
+    user.suppliers << suppler
+    other_user.suppliers << suppler
     stub_auth0_token_request
   end
 
@@ -14,6 +19,26 @@ RSpec.describe DeactivateUser do
 
       expect(result.success?).to eq(true)
       expect(result.failure?).to eq(false)
+    end
+
+    context 'when the user is the only active user for a supplier' do
+      let(:other_user) { create(:user, :inactive) }
+
+      it 'returns a failed result' do
+        result = described_class.new(user: user).call
+        expect(result).to be_failure
+      end
+
+      it 'does not delete the user in Auth0' do
+        expect_any_instance_of(DeleteUserInAuth0).not_to receive(:call)
+        described_class.new(user: user).call
+      end
+
+      it 'does not clear the auth_id of the user' do
+        original_auth_id = user.auth_id
+        described_class.new(user: user).call
+        expect(user.auth_id).to eql(original_auth_id)
+      end
     end
 
     context 'when Auth0 errors' do


### PR DESCRIPTION
## Description
- [NRMI-41: self serve user deactivate](https://crowncommercialservice.atlassian.net/browse/NRMI-41)

## Why was the change made?
- Improved user experience
- Reduced supplier user queries into RMI support
- Improved resilience
- Reduced ‘dead’ accounts

## Are there any dependencies required for this change?
List all the dependencies.

## What type of change is it?
Please delete options that are not relevant.

 [X] New feature 

## How was the change tested?
Unit and manual testing
